### PR TITLE
修复 sw_motion 缺失 Path 导入导致健康检查崩溃

### DIFF
--- a/scripts/sw_motion.py
+++ b/scripts/sw_motion.py
@@ -6,6 +6,7 @@ SolidWorks Motion Study 自动化工具。
 """
 import glob
 import os
+from pathlib import Path
 
 try:
     from .sw_preflight import import_com_dependencies


### PR DESCRIPTION
## 背景

`solidworks_health_check` 默认开启的 Motion 类型库分支抛 `NameError: name 'Path' is not defined`,导致健康检查以及旋转马达(`solidworks_add_rotary_motor`)加载失败。

## 根因

`scripts/sw_motion.py` 的 `_motion_typelib_candidates()` 使用了 `pathlib.Path`,但模块顶部只导入了 `glob` / `os`,漏了 `from pathlib import Path`。属于孤例——仓内其余使用 `Path` 的脚本都已正确导入。

## 修复

```diff
 import glob
 import os
+from pathlib import Path
```

## 验证

修复后在本机 SolidWorks 2024 上做了分层全量验收,相关项全绿:

- `solidworks_health_check` 全绿(`motion_type_library_ready = true`)
- `solidworks_add_rotary_motor` → `inspect_motion_studies` → `validate_motion_study`:7 项交付门禁全过(此前必崩的马达分支现已能建立马达并完成计算)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
