### PR TITLE
工程图:GB/T 1804-m 尺寸公差标注、坐标扫描式标注与测量/质量属性模块

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -106,11 +106,15 @@ session.export(model, r"C:\temp\cylinder.step")
 | 装配体操作、齿轮/铰链/可拖动运动配合 | `scripts/sw_assembly.py` | `references/assembly.md` |
 | Motion Study 运动算例、旋转马达与结果审计 | `scripts/sw_motion.py` | `references/motion-study.md`、`references/complex-mechanical-routing.md` |
 | 工程图出图 | `scripts/sw_drawing.py` | `references/drawing.md` |
+| 尺寸公差标注（对称 ±/上下限 + GB/T 1804-m） | `scripts/sw_drawing.py` | `references/tolerances.md` |
+| 坐标扫描式工程图尺寸标注（无模型尺寸件） | `scripts/sw_drawing.py` | `references/drawing.md`、`references/tolerances.md` |
 | 文件导出 | `scripts/sw_export.py` | `references/export.md` |
 | 参数修改与自定义属性 | `scripts/sw_document_data.py` | `references/advanced.md` |
 | 装配 BOM CSV 与 Pack and Go | `scripts/sw_delivery.py` | `references/export.md` |
 | OBJ/STL 高还原网格参考导入 | `scripts/sw_import_mesh_reference.py` | `references/mesh-reference-import.md` |
 | 结果自审查 | `scripts/sw_review.py` | `references/review.md` |
+| 质量属性（质量/体积/表面积/重心） | `scripts/sw_mass_properties.py` | `references/mass-properties.md` |
+| 测量与装配检查原语（整体尺寸/包围盒/组件计数） | `scripts/sw_inspect.py` | `references/measurement.md` |
 | 语义实体引用 | `scripts/sw_entity_reference.py` | 逐步替代 Face1/Edge1 和屏幕坐标 |
 | DFM 制造风险复核 | `scripts/dfm_review.py`、`scripts/dfm_profiles.py`、`scripts/cad_studio.py check-dfm` | 供应商 profile、B-Rep 证据、机加工、钣金、激光切割和 3D 打印的结构化规则检查 |
 | Routing 中性复核与前置 | `scripts/routing_review.py`、`scripts/cad_studio.py check-routing`、`scripts/cad_studio.py routing-preflight` | 端点、分段、长度、弯曲半径、碰撞/间隙、支撑、Routing BOM；原生写入必须等加载项/许可证证据 |
@@ -173,6 +177,8 @@ from sw_connect import connect_solidworks, mm, deg, new_document
 3. 长引线只能做局部说明，不能替代尺寸链；不得跨视图、压孔、压中心线、压尺寸文字或侵入标题栏。
 4. 密集孔槽必须优先用孔表、槽表或孔槽明细表，表内写清部位、规格、数量和定位；表格不能成为逃避定位尺寸的借口。
 5. 交付前必须目视复核预览图，发现漏标、重叠、压线或标题栏侵入时先返工再汇报。
+6. 需要按坐标点选标注尺寸（无模型驱动尺寸的导入件/占位件）时，视图比例必须 ≥1:2（低于 1:2 SolidWorks 不暴露可点选边/面，扫描会静默失败），大件放不下可选比例时升用 A2；比例须用 `ScaleDecimal` 强制，不能依赖图纸比例默认值（`UseSheetScale` 默认 True 会忽略设定）。
+7. 制造用的工程图尺寸必须带公差：未特别指明时按 GB/T 1804-m 通用公差（按名义尺寸分档）标注对称 ± 公差；关键配合面（孔轴配合、定位配合）必须单独标注配合公差并人工复核。
 
 ### 高还原外观/公开网格参考模型
 

--- a/capabilities.yaml
+++ b/capabilities.yaml
@@ -272,6 +272,62 @@
       "dependencies": ["python", "可选 SolidWorks Routing 类型库和加载项许可证"],
       "limitations": ["当前支持中性 Routing 端点、分段、长度、弯曲半径、碰撞/间隙、支撑间距和 BOM 复核；不生成 SOLIDWORKS Routing 原生特征", "本机 SW2026 可发现 SWRoutingLib.tlb 和核心接口，但未检测到 Routing AddIn 注册或许可证证据时原生写入必须 blocked"],
       "allowed_modes": ["interactive", "reviewed"]
+    },
+    {
+      "id": "dimension_tolerances",
+      "label": "尺寸公差标注（对称/上下限 + GB/T 1804-m）",
+      "level": "pilot",
+      "backends": ["solidworks-com"],
+      "verified_versions": ["2024"],
+      "dependencies": ["SolidWorks", "pywin32"],
+      "limitations": [
+        "通过 IDimension.SetToleranceType + SetToleranceValues 设置对称（±）或上下限公差；GB/T 1804-m 通用公差按名义尺寸分档（≤6±0.1 / ≤30±0.2 / ≤120±0.3 / ≤400±0.5 / >400±0.8）",
+        "公差值单位为米；带宽按已知名义尺寸查表，不读尺寸回读值（GetValue2/SystemValue 单位不一致会错档）；必须用 SetToleranceType 方法启用显示，ITolerance.Type 属性赋值只写数据不渲染",
+        "SW2024 已在 5 个自制件工程图上连续回归（每张 W/H/D 三向 ±GB/T 1804-m）；仅覆盖尺寸公差，GD&T 几何公差框仍为 reference_only，关键配合公差须人工标注复核"
+      ],
+      "allowed_modes": ["interactive", "reviewed"]
+    },
+    {
+      "id": "drawing_edge_scan_dimensioning",
+      "label": "坐标扫描式工程图尺寸标注",
+      "level": "pilot",
+      "backends": ["solidworks-com"],
+      "verified_versions": ["2024"],
+      "dependencies": ["SolidWorks", "pywin32"],
+      "limitations": [
+        "对无模型驱动尺寸的零件（导入件/占位件/只含拉伸参数件）按坐标点选扫描边线标注：视图轮廓粗扫→二分定位边界→微扫落在可选边→SelectByID2 两点→AddDimension2（重试）",
+        "要求视图比例≥1:2（低于阈值 SolidWorks 不暴露可点选边/面，扫描静默失败）；须用 ScaleDecimal 强制真实比例（UseSheetScale 默认 True 会忽略设定）；新建视图须先存盘才暴露全部边线；SelectByID2 作用于活动文档",
+        "SW2024 已在 5 个自制件工程图上连续回归；复杂剖面/局部放大图未覆盖；尺寸位置、重叠和尺寸链完整性仍需目视复核"
+      ],
+      "allowed_modes": ["interactive", "reviewed"]
+    },
+    {
+      "id": "mass_properties",
+      "label": "质量属性（质量/体积/表面积/重心）",
+      "level": "pilot",
+      "backends": ["solidworks-com"],
+      "verified_versions": ["2024"],
+      "dependencies": ["SolidWorks", "pywin32"],
+      "limitations": [
+        "通过 IModelDocExtension.GetMassProperties2 读取质量/体积/表面积/重心（SI；mm³=×1e9、mm²=×1e6）；质量依赖材料密度，未设材料时质量无意义，须先指定材料或人工确认",
+        "经 sw.ActiveDoc.Extension 调用（OpenDoc6 返回的未类型化派发上部分文档级方法不可解析）；密度未配或几何异常时返回 review_required，不伪造数值",
+        "SW2024 已在 3 个外购件上回归体积/表面积；密度赋值（InsertMaterial）尚未封装，关联 appearance 能力为 TODO"
+      ],
+      "allowed_modes": ["interactive", "reviewed"]
+    },
+    {
+      "id": "measurement_and_inspection",
+      "label": "测量与装配检查原语",
+      "level": "pilot",
+      "backends": ["solidworks-com"],
+      "verified_versions": ["2024"],
+      "dependencies": ["SolidWorks", "pywin32"],
+      "limitations": [
+        "零件整体尺寸用临时工程图 GetOutline@1:1（前视图给 W×H、俯视图给 W×D；类型化视图恒可用，对未类型化文档 GetBox 不可解析时仍可靠）；包围盒 GetBox(0)/GetBodyBox；装配组件计数 GetComponents+GetPathName（不用 Name2 属性）；特征/尺寸枚举 GetFirstFeature 链",
+        "整体尺寸为视图轮廓含余量近似；包围盒可能非原点对称须读 min/max；占位几何的外购件 BOM 规格须按功能意图+装配堆叠确认，不得直接采用模型测量值",
+        "SW2024 已在电机项目回归（3 外购件整体尺寸、装配组件计数 螺栓×8/钻头×1/钻夹头×1）"
+      ],
+      "allowed_modes": ["interactive", "reviewed"]
     }
   ]
 }

--- a/examples/gen_manufacturing_drawing.py
+++ b/examples/gen_manufacturing_drawing.py
@@ -1,0 +1,100 @@
+"""
+示例: 生成带尺寸 + GB/T 1804-m 公差的加工工程图
+对**无模型驱动尺寸**的零件（导入件 / 占位件 / 只含拉伸参数件）做坐标扫描式标注，
+并按 GB/T 1804-m 通用公差自动套对称 ±。
+
+演示新增封装端到端：
+  force_view_scale / pickability_ok / scan_view_dimensions（含 apply_gb1804m）
+  + 文档级显示偏好（第一角 / 毫米 / 小数位，须在建视图前设）+ 存盘后扫描 + PDF 导出。
+
+修改下方 PART_PATH / 名义尺寸 / 比例后即可对自制件复用。
+"""
+import os
+import sys
+
+sys.path.insert(0, r"../scripts")
+
+from sw_connect import connect_solidworks, new_document, open_document, get_com_member
+from sw_drawing import (
+    add_view,
+    force_view_scale,
+    pickability_ok,
+    scan_view_dimensions,
+    export_sheet_to_pdf,
+)
+
+# ===== 配置（按你的零件改） =====
+PART_PATH = r"C:\parts\mypart.sldprt"
+DRAWING_PATH = r"C:\exports\mypart.SLDDRW"
+PDF_PATH = r"C:\exports\mypart.pdf"
+# 名义尺寸（mm）：仅用于 GB/T 1804-m 公差分档，不必精确到视图轮廓
+NOMINAL_WIDTH_MM = 80.0
+NOMINAL_HEIGHT_MM = 60.0
+NOMINAL_DEPTH_MM = 40.0
+SCALE = 1.0            # 视图比例；≥0.5 才可点选边/面，大件至少 0.5（1:2）
+FRONT_X, FRONT_Y = 0.15, 0.20   # 前视图放置位置（米）
+TOP_X, TOP_Y = 0.15, 0.08       # 俯视图位置（前视图下方）
+
+
+def main():
+    if not os.path.exists(PART_PATH):
+        print("零件不存在: %s（改 PART_PATH 后重试）" % PART_PATH)
+        return
+
+    sw, _ = connect_solidworks()
+
+    # 零件须先加载进会话，CreateDrawViewFromModelView3 才能引用
+    open_document(sw, PART_PATH, silent=True)
+
+    drawing = new_document(sw, "drawing")
+
+    # 文档级显示偏好：必须在创建视图/尺寸【之前】设（显示样式创建即锁定）。
+    # 整数为 SW2024 实证值；跨版本/语言按 references/api-lookup.md 查证枚举。
+    get_com_member(drawing, "SetUserPreferenceIntegerValue", 79, 1)    # 第一角投影
+    get_com_member(drawing, "SetUserPreferenceIntegerValue", 263, 5)   # 单位制 MMGS（毫米）
+    get_com_member(drawing, "SetUserPreferenceIntegerValue", 49, 0)    # 线性尺寸小数位 = 0
+
+    # 前视图 + 俯视图（比例由 force_view_scale 强制；add_view 的 scale 占位即可）
+    front = add_view(drawing, PART_PATH, "*Front", FRONT_X, FRONT_Y)
+    top = add_view(drawing, PART_PATH, "*Top", TOP_X, TOP_Y)
+
+    # 强制真实比例（Scale 参数被 UseSheetScale 忽略）+ 可选择性门禁（≥1:2）
+    for name, vw in (("Front", front), ("Top", top)):
+        fr = force_view_scale(vw, SCALE, drawing_model=drawing)
+        pk = pickability_ok(vw)
+        print("  视图 %s: 强制=%s 比例=%s 可选=%s" % (name, fr["status"], pk.get("scale"), pk["status"]))
+        if pk["status"] != "pass":
+            print("    ! 比例 %s < 1:2，点选不可用：%s" % (pk.get("scale"), pk.get("reason")))
+            print("    ! 请提升 SCALE 或换 A2 图幅再放可选比例。")
+
+    # 新建视图仅暴露部分剪影边 —— 存盘后全部边线才可点选
+    get_com_member(drawing, "SaveAs3", DRAWING_PATH, 0, 0)
+    # SelectByID2 作用于活动文档：new_document 返回的 drawing 已是活动文档；
+    # 多文档场景（同时还开着别的工程图）扫描前须 sw.ActivateDoc3(DRAWING_PATH, ...)
+
+    # 坐标扫描式标注 W/H/D，自动套 GB/T 1804-m 对称公差
+    report = scan_view_dimensions(
+        drawing, front, top,
+        nominal_width_mm=NOMINAL_WIDTH_MM,
+        nominal_height_mm=NOMINAL_HEIGHT_MM,
+        nominal_depth_mm=NOMINAL_DEPTH_MM,
+        apply_tolerance=True,
+    )
+    print("扫描标注: %s" % report["status"])
+    for d in report.get("dimensions", []):
+        tr = d.get("tolerance_report") or {}
+        print("  %s: set=%s 公差=%s/%s (type=%s)" % (
+            d["axis"], d.get("display_dimension_set"),
+            tr.get("plus_mm"), tr.get("minus_mm"), tr.get("tolerance_type")))
+    if report["status"] != "pass":
+        print("  ! 部分边线未定位: %s —— 须目视补标" % report.get("error_code"))
+
+    # 重建 + 保存 + 导出 PDF
+    get_com_member(drawing, "EditRebuild3")
+    get_com_member(drawing, "Save")
+    export_sheet_to_pdf(drawing, PDF_PATH)
+    print("完成: %s / %s" % (DRAWING_PATH, PDF_PATH))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/inspect_part.py
+++ b/examples/inspect_part.py
@@ -1,0 +1,68 @@
+"""
+示例: 零件 / 装配体检查
+读取质量属性、整体尺寸、包围盒、装配组件计数、特征枚举。
+全部只读，不改、不保存被测文档（临时测量图测完即关）。
+
+演示新增封装：mass_properties / overall_dimensions / bounding_box /
+count_components / enumerate_features。修改下方路径后即可复用。
+"""
+import os
+import sys
+
+sys.path.insert(0, r"../scripts")
+
+from sw_connect import connect_solidworks, open_document
+from sw_mass_properties import mass_properties
+from sw_inspect import (
+    overall_dimensions,
+    bounding_box,
+    count_components,
+    enumerate_features,
+)
+
+PART_PATH = r"C:\parts\mypart.sldprt"
+ASSEMBLY_PATH = r"C:\parts\myassembly.sldasm"
+
+
+def main():
+    sw, _ = connect_solidworks()
+
+    if os.path.exists(PART_PATH):
+        print("=== 零件: %s ===" % os.path.basename(PART_PATH))
+        model = open_document(sw, PART_PATH, silent=True)
+
+        mp = mass_properties(model)
+        print("质量属性: status=%s 材料=%s" % (mp["status"], mp.get("material") or "(未设)"))
+        if mp.get("volume_mm3") is not None:
+            print("  体积=%.1f mm³  表面积=%.1f mm²" % (mp["volume_mm3"], mp["surface_mm2"]))
+        if mp["mass_meaningful"]:
+            print("  质量=%.4f kg  重心(mm)=%s" % (mp["mass_kg"], mp["center_of_mass_mm"]))
+        else:
+            print("  质量=%s kg（材料/密度未设，须人工指定）" % mp.get("mass_kg"))
+
+        # overall_dimensions 内部自行开零件；此处已打开则复用、不重复关
+        od = overall_dimensions(sw, PART_PATH, close_part=False)
+        print("整体尺寸: W=%s H=%s D=%s mm (status=%s，含~6mm 余量近似)" % (
+            od["width_mm"], od["height_mm"], od["depth_mm"], od["status"]))
+
+        bb = bounding_box(model)
+        print("包围盒: size(mm)=%s via %s" % (bb["size_mm"], bb["method"]))
+
+        feats = enumerate_features(model, max_features=20)
+        print("特征(%d%s):" % (feats["count"], "..." if feats["truncated"] else ""))
+        for f in feats["features"][:5]:
+            dims = ", ".join("%s=%.3f" % (d["name"], d["value_mm"])
+                             for d in f["dimensions"] if d.get("value_mm") is not None)
+            print("  [%d] %s (%s)%s" % (f["index"], f["name"], f["type"], ("  " + dims) if dims else ""))
+
+    if os.path.exists(ASSEMBLY_PATH):
+        print("\n=== 装配体: %s ===" % os.path.basename(ASSEMBLY_PATH))
+        asm = open_document(sw, ASSEMBLY_PATH, silent=True)
+        cc = count_components(asm, flat=True)
+        print("组件计数(flat): total=%s status=%s" % (cc["total"], cc["status"]))
+        for name, n in sorted(cc["counts"].items(), key=lambda kv: -kv[1]):
+            print("  %s ×%d" % (name, n))
+
+
+if __name__ == "__main__":
+    main()

--- a/references/drawing.md
+++ b/references/drawing.md
@@ -39,6 +39,27 @@ view.ScaleRatio = (1.0, 2.0)  # 1:2 比例
 view.ScaleRatio = (2.0, 1.0)  # 2:1 比例
 ```
 
+### 视图比例与可选择性（≥1:2 阈值）
+
+视图**比例低于 1:2 时，SolidWorks 不暴露可点选的边/面**：视图照常渲染，但 `SelectByID2`
+坐标点选恒返回 `type=12`（视图对象），拿不到边（1）或面（2），坐标扫描式标注因此静默
+失败。本机 SW2024 `probe_scale` 实证：比例 0.50 可点选、0.45 不可点选。
+
+- `CreateDrawViewFromModelView3(part, view, x, y, scale)` 的 `scale` 参数在
+  `UseSheetScale` 默认 `True` 时**被忽略**，大件会静默落到图纸比例（常 <1:2）。必须显式
+  关闭并写 `ScaleDecimal` 强制真实比例：
+
+```python
+view.UseSheetScale = False
+view.ScaleDecimal = 1.0          # 或目标比例
+drawing.EditRebuild3()           # 重建使比例生效
+```
+
+- 大件（≥~300mm）在 A3 上放不下可选比例时，改用 A2 图幅再提升比例。
+- 封装：`sw_drawing.force_view_scale(view, scale, drawing_model=drawing)` 一步完成强制
+  + 重建 + 回读 `ScaleRatio` 验证；`sw_drawing.pickability_ok(view)` 读比例做门禁自检
+  （返回 `status=blocked` + `threshold` / `reason`）。
+
 ## 尺寸标注
 
 ### 自动标注（模型项目）
@@ -125,15 +146,75 @@ python -m pip install -r requirements-pdf.txt
 因此工程图边界证据强度依次为：PDF 矢量文字边界 > COM 锚点/字体保守估算 > OCR，
 最终交付仍保留一次 PDF/BMP 目视复核。
 
-### 手动添加尺寸
+### 坐标扫描式尺寸标注
+
+对**没有模型驱动尺寸**的零件（导入件 / 占位件 / 只含拉伸参数件），模型项目自动标注
+拿不到尺寸，需按坐标点选扫描边线手动标注：
+
+1. 取视图轮廓 `view.GetOutline()` → `[xmin, ymin, xmax, ymax]`（米）。
+2. 粗扫（24 步）定位 空→实体 过渡，二分（16 次）精确边界，再 ±0.9mm/0.1mm 微扫落在
+   `seltype==1`（边）的坐标上（`sw_drawing.find_edge`）。
+3. `SelectByID2("", "", x, y, 0, append, …)` 坐标点选两条边 → `AddDimension2`（重试 ≤4 次；
+   刚创建视图几何未稳态时点选会瞬时失败）。
+4. 竖向（H/D）扫描用 `sw_drawing.find_solid_x` 取一个落在实体面（`seltype==2`）上的 X 做
+   固定轴，避开中央空隙（如夹爪）和竖边。
 
 ```python
-# 先选择两个实体
-drawing.Extension.SelectByID2("Edge1@View1", "EDGE", 0, 0, 0, False, 0, None, 0)
-drawing.Extension.SelectByID2("Edge2@View1", "EDGE", 0, 0, 0, True, 0, None, 0)
-# 添加尺寸
-drawing.AddDimension2(x, y, 0)  # 尺寸标注放置位置
+from sw_drawing import scan_view_dimensions, force_view_scale, pickability_ok
+
+# 前置：工程图已激活、视图已存盘、比例≥1:2（新建视图仅暴露部分剪影边，存盘后全部边线可选）
+for vw in (front_view, top_view):
+    force_view_scale(vw, scale, drawing_model=drawing)
+    assert pickability_ok(vw)["status"] == "pass"
+
+report = scan_view_dimensions(
+    drawing, front_view, top_view,
+    nominal_width_mm=W, nominal_height_mm=H, nominal_depth_mm=D,
+    apply_tolerance=True,        # 自动套 GB/T 1804-m
+)
+# report["dimensions"] = [{"axis":"W","display_dimension_set":True,"tolerance_report":{...}}, …]
 ```
+
+选择类型经 `SelectionManager.GetSelectedObjectType6(idx, -1)`（回退 Type5/4/3）读取，
+**跳过 `type=12` 的视图对象**（点选恒在 idx1 抓到）：`1`=边、`2`=面、`12`=视图对象。
+`SelectByID2` 作用于**活动文档**——多文档时须先 `ActivateDoc3` 目标工程图。
+
+> 仅覆盖整体 W/H/D 三向；复杂剖面、局部放大图、尺寸链完整性未覆盖，须目视复核。
+
+### 尺寸公差标注
+
+为 `DisplayDimension` 设置对称 ± / 上下限公差（完整 API 与枚举见 `references/tolerances.md`）：
+
+```python
+from sw_drawing import apply_gb1804m, set_dimension_tolerance
+
+# 便捷：按 GB/T 1804-m 套对称 ±（按已知名义尺寸查表分档）
+apply_gb1804m(display_dimension, nominal_mm=45.0)          # ±0.2
+
+# 显式上下限（tol_type=5 双向）
+set_dimension_tolerance(display_dimension, 45.0, tol_type=5, plus_mm=0.2, minus_mm=0.1)
+```
+
+三个必踩坑：①必须用 `IDimension.SetToleranceType` **方法**启用 ± 显示（`ITolerance.Type=`
+属性赋值只写数据不渲染）；②带宽按**已知名义尺寸**查表，不读尺寸回读值
+（`GetValue2/SystemValue` 单位不一致会错档）；③`SetToleranceValues` 取**米**
+（±0.2mm → 0.0002）。
+
+## 工程图显示偏好
+
+第一角投影、毫米单位、小数位等是**文档级**偏好，须在**创建视图/尺寸之前**设置
+（显示样式在创建时锁定；事后改不回溯已建对象）。设在工程图文档上，而非应用级——
+应用级 `SetUserPreferenceIntegerValue` 返回 `False` 不生效。
+
+```python
+drawing.SetUserPreferenceIntegerValue(79, 1)    # 第一角投影（GB/ISO）
+drawing.SetUserPreferenceIntegerValue(263, 5)   # 单位制 = MMGS（毫米）
+drawing.SetUserPreferenceIntegerValue(49, 0)    # 线性尺寸小数位 = 0
+```
+
+> 上述整数为本机 SW2024 实证值（枚举名见 `swconst.swUserPreferenceIntegerValue_e`）。
+> 跨版本/语言使用前请按 `references/api-lookup.md` 流程查证枚举整数；技能约定硬编码
+> 整数 + 注释枚举来源，不加载 `swconst.tlb`。
 
 ## 注释与标注
 

--- a/references/mass-properties.md
+++ b/references/mass-properties.md
@@ -1,0 +1,83 @@
+# 质量属性 API 参考
+
+读取零件/装配体的质量、体积、表面积和重心。能力清单记录为 `mass_properties=pilot`
+（SW2024 已在 3 个外购件上回归体积/表面积）。
+
+## API 路径
+
+```python
+# model: 已打开的零件或装配体文档（IModelDoc2）。Extension 是属性，不要当方法调用。
+extension = model.Extension                       # IModelDocExtension（属性）
+status = VARIANT(pythoncom.VT_BYREF | pythoncom.VT_I4, 0)
+props = extension.GetMassProperties2(accuracy, status, default_density)
+# accuracy:        0=普通精度
+# default_density: 当几何未指定材料时使用的兜底密度（kg/m³），通常传 0.0
+```
+
+`GetMassProperties2` 返回一个浮点数组（顺序固定，SI 单位）：
+
+| 索引 | 含义 | 单位 |
+|---|---|---|
+| 0,1,2 | 重心 X/Y/Z | m |
+| 3 | 体积 | m³ |
+| 4 | 表面积 | m² |
+| 5 | 质量 | kg |
+| 6 | 惯性主轴 xx | kg·m² |
+| 7,8,9 | 惯性张量（绕重心） | kg·m² |
+
+换算到毫米/克：体积 `m³ × 1e9 = mm³`，表面积 `m² × 1e6 = mm²`，重心 `m × 1000 = mm`。
+
+## 必须经过 `sw.ActiveDoc.Extension`
+
+`sw.OpenDoc6(...)` 在动态派发下返回**未类型化**的 IDispatch；在其上调用 `GetBox`、
+`GetFirstFeature` 等文档级方法常报 “Member not found”。可靠做法：打开后取
+`pdoc = sw.ActiveDoc`（属性，经 `get_com_member` 读取），再 `pdoc.Extension` →
+`GetMassProperties2`。技能封装 `sw_connect.open_document()` 已处理这层激活与派发问题。
+
+## 质量依赖材料密度
+
+`props[5]`（质量）只有在该文档**已指定材料/密度**时才有意义：
+
+- 未指定材料时，SolidWorks 用上一次的默认密度或 0；质量可能为 0 或荒谬值。
+- `default_density` 参数只是几何**没有材料**时的兜底，不能替代真实材料赋值。
+- 封装在检测到材料未赋或质量明显异常（如 0）时返回 `status="review_required"`，
+  **不伪造数值**；调用方须先指定材料或人工确认。
+
+> 材料赋值（`InsertMaterial` / `SetMaterialPropertyName`）目前**尚未封装**，关联
+> `appearance` 能力为 TODO。在此之前，质量字段一律标记为需人工复核。
+
+## 技能封装（`scripts/sw_mass_properties.py`）
+
+```python
+from sw_connect import connect_solidworks, open_document
+from sw_mass_properties import mass_properties
+
+sw, _ = connect_solidworks()
+model = open_document(sw, r"D:\parts\bolt.sldprt")
+report = mass_properties(model)
+# -> {
+#      "status": "pass" | "review_required",
+#      "mass_kg": ...,            # 材料未赋时可能无意义 -> review_required
+#      "volume_mm3": ...,
+#      "surface_mm2": ...,
+#      "center_of_mass_mm": [x, y, z],
+#      "mass_meaningful": bool,
+#      "accuracy": 0,
+#      "review_required": True,    # 质量始终须人工复核材料
+#      "limitations": [...],
+#    }
+```
+
+`mass_properties(model)` 只读不改；不保存、不修改文档。
+
+## 回归证据
+
+SW2024 电机项目 3 个外购件实测（`probe_parts.py`）：
+
+| 件 | 体积（mm³） | 表面积（mm²） |
+|---|---|---|
+| 螺栓M8（占位几何） | 1099.6 | — |
+| 钻头M5（占位几何） | 484.9 | — |
+| 钻夹头（占位几何） | 2650.7 | — |
+
+> 这些是**占位几何**的体积，仅用于验证 API 通路；真实采购件体积/质量须以厂商图纸为准。

--- a/references/measurement.md
+++ b/references/measurement.md
@@ -1,0 +1,111 @@
+# 测量与装配检查原语 API 参考
+
+提供零件整体尺寸、包围盒、装配体组件计数和特征/尺寸枚举等只读检查原语。能力清单记录为
+`measurement_and_inspection=pilot`（SW2024 已在电机项目回归 3 外购件整体尺寸与装配组件计数）。
+
+## 零件整体尺寸（最可靠：临时工程图 GetOutline@1:1）
+
+对未类型化的 `OpenDoc6` 派发，`GetBox` 常不可解析；而工程图视图是**类型化**对象，
+`GetOutline()` 恒可用、且与可选择性无关。因此整体尺寸用一张临时工程图测量：
+
+```python
+# 1. 新建一张临时工程图
+drawing = new_document(sw, "drawing")
+# 2. 画前视图 + 俯视图，比例强制 1:1（UseSheetScale=False + ScaleDecimal=1.0）
+front = drawing.CreateDrawViewFromModelView3(part_path, "*Front", x, y, 0)
+top   = drawing.CreateDrawViewFromModelView3(part_path, "*Top",   x, y, 0)
+# 3. 读视图轮廓（米）-> 换算 mm
+ol = front.GetOutline()      # [xmin, ymin, xmax, ymax]，单位米
+width_mm  = (ol[2] - ol[0]) * 1000.0
+height_mm = (ol[3] - ol[1]) * 1000.0
+```
+
+- 前视图给 **W（X）× H（Y）**；俯视图给 **W（X）× D（Y）**。
+- W 取前/俯两视图的平均（两者应一致，取平均抑制微小数值差）。
+- 视图轮廓含约 6 mm 余量（1:1 下），所以是**含余量的近似**，不是严格名义尺寸。
+- 测完关闭临时图（不保存）。
+
+> 比例必须强制为 1:1，否则 `GetOutline` 返回的是缩放后的米值。强制方法见
+> `references/drawing.md` 的“视图比例与可选择性”。
+
+## 包围盒
+
+```python
+# 类型化文档上可用（OpenDoc6 未类型化派发上可能 Member not found -> 回退到上面的临时图法）
+box = model.GetBox(0)        # -> [xmin, ymin, zmin, xmax, ymax, zmax]，单位米
+dx_mm = (max(box[0], box[3]) - min(box[0], box[3])) * 1000.0
+# ...同理 dy, dz
+```
+
+- `GetBox(0)` 取实体包围盒；零件可能**非原点对称**，必须读 min/max，不能用 ±box[0]。
+- 多实体零件：`model.GetBodies2(0, False)` 遍历各 `IBody2.GetBodyBox()` 取并集。
+- 仍不可解析时回退到临时工程图法。
+
+## 装配体组件计数
+
+```python
+# adoc: 已打开的装配体文档
+components = adoc.GetComponents(True)   # True=扁平（所有实例），False=仅顶层
+for comp in components:
+    path = comp.GetPathName()           # 真方法 -> 可经 get_com_member 调用；返回模型文件全路径
+    name = os.path.splitext(os.path.basename(path))[0]   # 去扩展名即零件名
+```
+
+- **不要用 `IComponent2.Name2` 属性**做计数：在动态派发下若被当方法处理会返回访问器函数
+  对象，破坏计数。`GetPathName()` 是真方法，安全。
+- `GetComponents(True)` 返回所有实例（含子装配内件），适合统计采购件数量；
+  `GetComponents(False)` 只给顶层，适合看装配结构。
+
+## 特征 / 尺寸枚举
+
+```python
+feat = model.GetFirstFeature()
+while feat is not None:
+    name = feat.Name                       # 属性
+    type_name = feat.GetTypeName2()        # 方法
+    for dim in feat.GetDimensions():       # 方法 -> IDimension 数组
+        full_name = dim.FullName           # 属性
+        value_m = dim.SystemValue          # 属性（米）
+    feat = feat.GetNextFeature()
+```
+
+`Name` / `FullName` / `SystemValue` 是属性（经 `get_com_member` 无参读取）；
+`GetTypeName2` / `GetDimensions` / `GetNextFeature` 是方法（带参或显式调用）。
+
+## 技能封装（`scripts/sw_inspect.py`）
+
+```python
+from sw_connect import connect_solidworks, open_document
+from sw_inspect import overall_dimensions, bounding_box, count_components, enumerate_features
+
+sw, _ = connect_solidworks()
+
+# 整体尺寸（内部建/弃临时工程图）
+dims = overall_dimensions(sw, r"D:\parts\bolt.sldprt")
+# -> {"status":"pass", "width_mm":.., "height_mm":.., "depth_mm":.., "method":"throwaway_drawing_getoutline_at_1to1", ...}
+
+# 包围盒（类型化文档）
+model = open_document(sw, r"D:\parts\bolt.sldprt")
+bb = bounding_box(model)
+comps = count_components(open_document(sw, r"D:\asm\station.sldasm"), flat=True)
+feats = enumerate_features(model, max_features=200)
+```
+
+`count_components` 返回 `{"status":"pass", "counts":{name: n, ...}, "total": N, "flat": True}`。
+
+## 占位几何告诚
+
+外购/标准件在装配体中常为**示意占位几何**（实测一个 “M8 螺栓” 零件整体尺寸约
+22×22×26 mm，与真实 M8×45 螺栓完全不符）。因此：
+
+- **不得**直接拿模型测量值填 BOM 规格栏。
+- 外购件规格须按**功能意图 + 装配堆叠**确定（如按夹紧厚度推算螺栓长度），不确定的参数
+  （长度、直径、接口）在 BOM 中标 “请复核”。
+- 整体尺寸/包围盒只用于验证 API 通路和装配空间检查，不作为采购规格依据。
+
+## 回归证据
+
+SW2024 电机项目（`measure_parts.py` / `count_parts.py`）：
+
+- 3 个外购件整体尺寸经临时图法测得（占位值，仅验证通路）。
+- 装配组件计数（扁平）：螺栓M8 ×8、钻头M5 ×1、钻夹头 ×1 —— 用于生成采购 BOM 数量栏。

--- a/references/tolerances.md
+++ b/references/tolerances.md
@@ -1,0 +1,91 @@
+# 尺寸公差 API 参考
+
+为工程图上的 `DisplayDimension` 设置尺寸公差（对称 ±、上下限、MIN/MAX 等），并按
+GB/T 1804-m 通用公差按名义尺寸自动分档。能力清单记录为 `dimension_tolerances=pilot`
+（SW2024 已在 5 个自制件工程图上连续回归，每张 W/H/D 三向 ±GB/T 1804-m）。
+
+> 本能力只覆盖**线性尺寸公差**。GD&T 几何公差框（形位公差、基准、轮廓度等）仍为
+> `reference_only`，关键配合（H7/g6 等）的配合公差须人工标注并复核。
+
+## API 路径
+
+```python
+# display_dimension: 工程图上已存在的 IDisplayDimension（来自 InsertModelAnnotations3/4
+# 或坐标扫描式标注 sw_drawing.edge_scan_dimension()）。
+dimension = display_dimension.GetDimension()      # -> IDimension
+dimension.SetToleranceType(tol_type)              # int: 见下表
+dimension.SetToleranceValues(plus_m, minus_m)     # float, float —— 单位为米
+```
+
+- `GetDimension()` 返回 `IDimension`；公差类型与公差值都设在它上面。
+- 技能封装统一经 `sw_connect.get_com_member()` 调用，兼容动态派发下属性/方法歧义。
+
+## 公差类型枚举（swTolType_e）
+
+| 值 | 枚举 | 说明 | SW2024 实证 |
+|---|---|---|---|
+| `0` | `swTolNONE` | 无公差 | — |
+| `1` | `swTolMIN` | 最小值 | — |
+| `2` | `swTolMAX` | 最大值 | — |
+| `3` | `swTolBASIC` | 基本尺寸（框格） | — |
+| `4` | `swTolSYMMETRIC` | 对称 ±（上下同值） | ✅ 已验证渲染 |
+| `5` | `swTolBILATERAL` | 双向（上下不同） | — |
+| `6` | `swTolLIMIT` | 极限尺寸 | — |
+
+> 未在本机验证的枚举值请先以 `references/api-lookup.md` 的流程查证 `swconst.tlb` 再使用；
+> 技能约定**硬编码整数 + 注释标明枚举来源**，不依赖 `SolidWorks.Interop.swconst.dll` 加载。
+
+## 三个必踩的坑
+
+1. **必须用 `SetToleranceType` 方法启用 ± 显示。** `dimension.Tolerance().Type = 4` 这类
+   属性赋值只写内部数据、**不触发渲染**，图面上看不到公差。只有 `SetToleranceType(4)`
+   会真正切换显示模式。
+2. **公差带宽按“已知名义尺寸”查表，不要读尺寸回读值。** `GetValue2` / `SystemValue`
+   在不同尺寸上的单位不一致（有的是 mm、有的是 m），直接拿回读值去查 GB/T 1804-m 会错档。
+   本能力的封装一律由调用方传入名义尺寸（mm）。
+3. **`SetToleranceValues` 取米。** ±0.2 mm 须传 `0.0002`，传 `0.2` 会得到荒谬结果。
+
+## GB/T 1804-m 通用公差（中等级）
+
+| 名义尺寸区间（mm） | 对称 ±（mm） |
+|---|---|
+| ≤ 6 | ±0.1 |
+| > 6 ～ ≤ 30 | ±0.2 |
+| > 30 ～ ≤ 120 | ±0.3 |
+| > 120 ～ ≤ 400 | ±0.5 |
+| > 400 | ±0.8 |
+
+> 这是 GB/T 1804 一般公差的“中等级 m”。未注公差的线性尺寸默认套用此表；精密或粗加工
+> 场合可改用 f（精密）/c（粗糙）/v（最粗）等级，但本封装只内置 m。
+
+## 技能封装（`scripts/sw_drawing.py`）
+
+```python
+from sw_drawing import gb1804m_band, set_dimension_tolerance, apply_gb1804m
+
+# 纯查表（可单测）
+band_mm = gb1804m_band(nominal_mm=45)        # -> 0.2
+
+# 显式对称 ±：plus/minus 留空时按 GB/T 1804-m 自动分档
+report = set_dimension_tolerance(display_dimension, nominal_mm=45.0)   # ±0.2
+
+# 便捷封装：直接套 GB/T 1804-m 对称公差
+report = apply_gb1804m(display_dimension, nominal_mm=45.0)
+
+# 显式上下限（双向，tol_type=5）
+report = set_dimension_tolerance(
+    display_dimension, nominal_mm=45.0, tol_type=5, plus_mm=0.2, minus_mm=0.1,
+)
+```
+
+`set_dimension_tolerance` / `apply_gb1804m` 返回证据字典，遵循工程图模块的统一约定
+（`status`、`tolerance_type`、`plus_mm`、`minus_mm`、`nominal_mm`、`band_source`、
+`rendered_via`、`manual_review_required`）。`status="pass"` 表示 `SetToleranceType` +
+`SetToleranceValues` 调用成功；但仍须目视复核图面是否真正显示公差（不同 SolidWorks
+版本/语言下个别尺寸类型可能不渲染，须以导出 PDF/BMP 复核为准）。
+
+## 回归证据
+
+SW2024 电机项目：工件 / 夹爪 / 支架 / 桌腿 / 桌面 5 个自制件工程图，每张 W/H/D 三向
+均按 GB/T 1804-m 标注对称公差，导出 PDF 目视确认 ± 公差正确显示。脚本来源为
+`examples/gen_manufacturing_drawing.py`（端到端：建图→扫描标注→套公差→导出 PDF）。

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -604,6 +604,100 @@ ok = apply_component_transform_x(component, 0.1, 0.0, 0.0, deg(30))
 4. 仍不稳定时，让用户确认后重启 `SLDWORKS.exe`。
 5. 脚本内记录失败组件和失败 API，不要只打印“完成”。
 
+### 视图比例低于 1:2 时边/面不可点选
+
+场景：坐标扫描式尺寸标注（`SelectByID2` 坐标点选）在大件视图上静默失败，拿不到边/面；
+`SelectionManager.GetSelectedObjectType6` 恒返回 `12`（视图对象）。
+
+原因：视图比例低于 1:2 时，SolidWorks 不向点选暴露边（1）或面（2），只返回视图对象（12）。
+视图仍正常渲染，故极易误判为“选区代码写错”。本机 SW2024 `probe_scale` 实证：0.50 可选、
+0.45 不可选。
+
+稳定写法：先用 `sw_drawing.pickability_ok(view)` 门禁自检；`status=blocked` 时调
+`sw_drawing.force_view_scale(view, scale, drawing_model=drawing)` 提升比例到 ≥0.5；大件
+（≥~300mm）A3 放不下可选比例时换 A2。
+
+验证方式：读回 `view.ScaleRatio` 确认 num/den ≥ 0.5；扫描后断言 `GetSelectedObjectType6`
+出现 1 或 2。
+
+### CreateDrawViewFromModelView3 的 Scale 参数被忽略
+
+场景：`CreateDrawViewFromModelView3(part, view, x, y, scale)` 传入大比例（如 5.0），视图
+却按图纸比例（常 1:5）渲染，叠加上一条导致不可点选。
+
+原因：视图 `UseSheetScale` 默认 `True`，创建时传入的 `scale` 被忽略，视图沿用图纸比例。
+
+稳定写法：创建后立即 `view.UseSheetScale = False; view.UseParentScale = False;
+view.ScaleDecimal = S; drawing.EditRebuild3()`，或直接调
+`sw_drawing.force_view_scale(view, S, drawing_model=drawing)`。
+
+验证方式：读 `view.ScaleRatio` 与目标一致（封装已回读验证 `verified=True`）。
+
+### 新建视图仅暴露部分剪影边（须先存盘）
+
+场景：对刚 `CreateDrawViewFromModelView3` 出的视图扫描，部分边可选、部分边（如右侧边）
+不可选，`find_edge` 在该侧返回 None，尺寸标注缺失。
+
+原因：新建视图的剪影边线尚未全部提交到点选管线；存盘提交视图几何后，全部边线可选。
+
+稳定写法：创建并强制比例后、扫描标注前，先 `drawing.SaveAs3(path, 0, 0)` 存盘；多文档时再
+`sw.ActivateDoc3(drawing.GetTitle(), False, 0, byref)` 确保扫描作用于目标工程图。
+
+验证方式：存盘前后各扫一次同一条边，对比 `find_edge` 是否从 None 变为坐标。
+
+### 尺寸公差属性赋值不渲染（须用 SetToleranceType 方法）
+
+场景：`displayDim.GetDimension().Tolerance().Type = 4` 后图面看不到 ± 公差。
+
+原因：`ITolerance.Type=` 属性赋值只写内部数据，不触发显示渲染；只有
+`IDimension.SetToleranceType(4)` 方法真正切换显示模式。
+
+稳定写法：用 `sw_drawing.set_dimension_tolerance(dd, nominal_mm)` / `apply_gb1804m(dd, nominal_mm)`；
+内部走 `SetToleranceType` + `SetToleranceValues`（公差值单位**米**）。
+
+验证方式：导出 PDF/BMP 目视确认 ± 显示；带宽按**已知名义尺寸**查 GB/T 1804-m，不读尺寸
+回读值（`GetValue2/SystemValue` 单位不一致会错档）。详见 `references/tolerances.md`。
+
+### OpenDoc6 未类型化派发上 GetBox 不可解析
+
+场景：`sw.OpenDoc6(...)` 返回的模型上调 `GetBox(0)` 报“找不到成员”或返回异常值。
+
+原因：`OpenDoc6` 在动态派发下返回未类型化的 IDispatch，部分文档级方法（GetBox、
+GetFirstFeature 等）在其上不可靠解析。
+
+稳定写法：测量用类型化路径——`sw_inspect.overall_dimensions(sw, path)`（临时工程图
+`GetOutline@1:1`，类型化视图恒可用，与可选择性无关）；包围盒用 `sw_inspect.bounding_box`
+（GetBox 不可解析时自动回退 `GetBodies2+GetBodyBox` 并集）。质量属性经 `model.Extension`
+（属性）调用，详见 `references/mass-properties.md`。
+
+验证方式：临时图法读到的 W/H/D 与已知名义尺寸误差在视图轮廓余量（~6mm）内。
+
+### 组件计数用 Name2 属性被 _FlagAsMethod 破坏
+
+场景：装配组件计数时对 `IComponent2.Name2` 调 `_FlagAsMethod("Name2")`，计数变成访问器
+函数对象数量而非真实组件数。
+
+原因：`Name2` 是属性；`_FlagAsMethod` 把它标记为方法后，读取返回的是访问器函数对象而非
+名称字符串，破坏 tally。`GetPathName()` 才是真方法。
+
+稳定写法：用 `sw_inspect.count_components(asm, flat=True)`；内部走 `GetComponents(flat)`
++ 每 `IComponent2.GetPathName()`（真方法）取 basename 去后缀计数，不碰 Name2。
+
+验证方式：扁平计数应与采购 BOM 数量一致（电机项目实证：螺栓M8×8 / 钻头M5×1 / 钻夹头×1）。
+
+### gencache 损坏导致枚举整数加载失败
+
+场景：想用 `SolidWorks.Interop.swconst` 读取 `swTolType_e`、`swUserPreferenceIntegerValue_e`
+等枚举的整数值，但 `gencache` 报错或生成的代理损坏。
+
+原因：pywin32 的 gencache 在版本/语言切换、权限或并发下会生成不一致或损坏的强类型代理。
+
+稳定写法：技能约定**硬编码整数 + 注释标明枚举来源**，不加载 `swconst.tlb`（如公差类型
+`SW_TOL_SYMMETRIC=4`、显示偏好 79/263/49）。跨版本/语言前按 `references/api-lookup.md`
+流程查证整数。COM 调用统一走 `get_com_member`，避免 `_FlagAsMethod` 的属性/方法误判。
+
+验证方式：硬编码值在本机 SW2024 实证（5 张公差图渲染、显示偏好生效）；换环境前复核。
+
 ## 未封装 API 调用
 
 当需要使用本 skill 尚未封装的 SolidWorks API 时：

--- a/scripts/sw_drawing.py
+++ b/scripts/sw_drawing.py
@@ -1117,3 +1117,457 @@ def export_sheet_to_pdf(model, output_path, sheet_names=None, sw_app=None):
     else:
         print(f"PDF 导出失败, 错误码: {errors.value}")
     return success
+
+
+# =============================================================================
+# 尺寸公差（dimension_tolerances）
+# 来源：SW2024 电机项目 gen_drawing.py set_tol。仅覆盖线性尺寸公差；GD&T 几何公差框
+# 仍为 reference_only。返回工程图模块统一证据字典（status∈pass|failed|review_required）。
+# =============================================================================
+
+# swTolType_e（SolidWorks.Interop.swconst）。技能约定：硬编码整数 + 注释枚举来源，
+# 不加载 swconst.tlb。
+SW_TOL_NONE = 0       # swTolNONE
+SW_TOL_MIN = 1        # swTolMIN
+SW_TOL_MAX = 2        # swTolMAX
+SW_TOL_BASIC = 3      # swTolBASIC
+SW_TOL_SYMMETRIC = 4  # swTolSYMMETRIC —— SW2024 已验证渲染
+SW_TOL_BILATERAL = 5  # swTolBILATERAL（上下不同）
+SW_TOL_LIMIT = 6      # swTolLIMIT
+
+# GB/T 1804 一般公差·中等级 m：(上界 mm, 对称 ± mm)，线性查表。
+_GB1804M_BANDS = (
+    (6.0, 0.1),
+    (30.0, 0.2),
+    (120.0, 0.3),
+    (400.0, 0.5),
+    (float("inf"), 0.8),
+)
+
+
+def gb1804m_band(nominal_mm):
+    """@brief GB/T 1804-m（一般公差·中等级）按名义尺寸线性分档，返回对称 ±（mm）。
+
+    纯查表函数，不接触 COM，可单测。
+    """
+    n = abs(float(nominal_mm))
+    for upper, band in _GB1804M_BANDS:
+        if n <= upper:
+            return band
+    return 0.8  # 防御性兜底（>400）
+
+
+def set_dimension_tolerance(display_dimension, nominal_mm, *, tol_type=SW_TOL_SYMMETRIC,
+                            plus_mm=None, minus_mm=None):
+    """@brief 为 DisplayDimension 设置尺寸公差。
+
+    默认对称（tol_type=4）。plus_mm/minus_mm 任一为 None 时，按 GB/T 1804-m 以名义尺寸
+    自动分档填充。公差值内部换算为米调用 IDimension.SetToleranceValues。
+
+    三个必踩坑（详见 references/tolerances.md）：
+      1. 必须用 SetToleranceType 方法启用 ± 显示（ITolerance.Type 属性赋值不渲染）；
+      2. 带宽按已知名义尺寸查表，不读尺寸回读值（GetValue2/SystemValue 单位会错档）；
+      3. SetToleranceValues 取米（±0.2mm → 0.0002）。
+
+    返回证据字典：status=pass 仅代表 COM 调用成功，是否真正渲染须以导出 PDF/BMP 目视复核。
+    """
+    result = {
+        "status": "failed",
+        "stage": "tolerance",
+        "tolerance_type": int(tol_type),
+        "nominal_mm": float(nominal_mm),
+        "plus_mm": None,
+        "minus_mm": None,
+        "band_source": None,
+        "rendered_via": "IDimension.SetToleranceType + SetToleranceValues",
+        "error_code": None,
+        "retryable": False,
+        "manual_review_required": True,
+    }
+    try:
+        auto = (plus_mm is None) or (minus_mm is None)
+        band = gb1804m_band(nominal_mm)
+        if plus_mm is None:
+            plus_mm = band
+        if minus_mm is None:
+            minus_mm = band
+        plus_mm = float(plus_mm)
+        minus_mm = float(minus_mm)
+        result["plus_mm"] = plus_mm
+        result["minus_mm"] = minus_mm
+        result["band_source"] = "gb1804m_m" if auto else "explicit"
+
+        dimension = get_com_member(display_dimension, "GetDimension")
+        if dimension is None:
+            result["error_code"] = "DRAWING_TOLERANCE_NO_DIMENSION"
+            return result
+
+        # 1) 启用显示（必须用方法，不是 ITolerance.Type= 属性赋值）
+        get_com_member(dimension, "SetToleranceType", int(tol_type))
+        # 2) 公差值，单位米：上差=+tol，下差=-tol（对称时两者同值）
+        get_com_member(dimension, "SetToleranceValues", plus_mm / 1000.0, -minus_mm / 1000.0)
+
+        result["status"] = "pass"
+    except Exception as exc:
+        result["error_code"] = "DRAWING_TOLERANCE_SET_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    return result
+
+
+def apply_gb1804m(display_dimension, nominal_mm):
+    """@brief 便捷封装：按 GB/T 1804-m 套对称 ± 公差。"""
+    return set_dimension_tolerance(display_dimension, nominal_mm, tol_type=SW_TOL_SYMMETRIC)
+
+
+# =============================================================================
+# 视图比例与坐标扫描式标注（drawing_edge_scan_dimensioning）
+# 来源：SW2024 电机项目 gen_drawing.py find_edge / find_solid_x / picktype / adddim。
+# 设计：find_edge / find_solid_x 为纯函数（注入 picktype 可单测）；make_picktype 把真实
+# 工程图接成 picktype；scan_view_dimensions 端到端编排（前视图 W/H + 俯视图 D）。
+# =============================================================================
+
+# 视图比例低于此阈值时，SolidWorks 不暴露可点选的边/面（点选恒返回 type=12 视图对象，
+# probe_scale 实证：0.50 可选 / 0.45 不可选）。
+PICKABILITY_THRESHOLD_SCALE = 0.5
+
+
+def pickability_ok(view):
+    """@brief 视图比例门禁自检：读 ScaleRatio，判断是否 ≥1:2。
+
+    返回 {status∈pass|blocked, scale, threshold, reason}。status=blocked 表示坐标扫描会
+    静默失败，调用方应先 force_view_scale。
+    """
+    ratio = _safe_member(view, "ScaleRatio", default=None)
+    scale = None
+    if isinstance(ratio, (tuple, list)) and len(ratio) == 2 and ratio[1]:
+        try:
+            scale = float(ratio[0]) / float(ratio[1])
+        except (TypeError, ValueError, ZeroDivisionError):
+            scale = None
+    result = {
+        "status": "blocked",
+        "stage": "pickability",
+        "scale": scale,
+        "threshold": PICKABILITY_THRESHOLD_SCALE,
+        "reason": None,
+    }
+    if scale is None:
+        result["reason"] = "无法读取视图 ScaleRatio"
+    elif scale < PICKABILITY_THRESHOLD_SCALE:
+        result["reason"] = (
+            "视图比例 %.3f 低于 %.2f（1:2），SolidWorks 不暴露可点选边/面；"
+            "先调 force_view_scale" % (scale, PICKABILITY_THRESHOLD_SCALE)
+        )
+    else:
+        result["status"] = "pass"
+    return result
+
+
+def force_view_scale(view, scale, *, drawing_model=None):
+    """@brief 强制视图真实比例，绕开 UseSheetScale 默认 True。
+
+    CreateDrawViewFromModelView3 的 Scale 参数在 UseSheetScale 默认 True 时被忽略，大件会
+    静默落到图纸比例（常 <1:2，低于可选择性阈值）。本函数：UseSheetScale=False +
+    UseParentScale=False + ScaleDecimal=scale，可选重建后回读 ScaleRatio 验证。
+
+    返回 {status∈pass|failed|review_required, scale, scale_ratio, verified}。
+    """
+    s = float(scale)
+    result = {
+        "status": "failed",
+        "stage": "scale",
+        "scale": s,
+        "scale_ratio": None,
+        "verified": False,
+        "error_code": None,
+        "retryable": False,
+        "manual_review_required": False,
+    }
+    try:
+        if hasattr(view, "UseSheetScale"):
+            view.UseSheetScale = False
+        if hasattr(view, "UseParentScale"):
+            view.UseParentScale = False
+        try:
+            view.ScaleDecimal = s
+        except Exception:
+            num, den = _scale_ratio(s)
+            view.ScaleRatio = (int(num), int(den))
+        if drawing_model is not None:
+            try:
+                get_com_member(drawing_model, "EditRebuild3")
+            except Exception:
+                pass
+        ratio = _safe_member(view, "ScaleRatio", default=None)
+        if isinstance(ratio, (tuple, list)) and len(ratio) == 2 and ratio[1]:
+            result["scale_ratio"] = [int(ratio[0]), int(ratio[1])]
+            actual = float(ratio[0]) / float(ratio[1])
+            result["verified"] = abs(actual - s) <= max(1e-6, abs(s) * 1e-3)
+            result["status"] = "pass"
+        else:
+            result["status"] = "review_required"
+            result["manual_review_required"] = True
+            result["error_code"] = "DRAWING_SCALE_READBACK_FAILED"
+    except Exception as exc:
+        result["error_code"] = "DRAWING_SCALE_FORCE_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    return result
+
+
+def find_edge(view_outline, axis, side, fixed, picktype, *,
+              coarse_steps=24, binary_iters=16, micro_range=0.0009):
+    """@brief 在视图轮廓 `axis` 方向 `side` 侧找到一条可点选边（seltype==1）的坐标。
+
+    纯函数（picktype 由调用方注入，可单测）。
+      view_outline: [xmin, ymin, xmax, ymax]（米）。
+      axis: 0=沿 X 扫描（变 X，固定 Y），1=沿 Y 扫描（变 Y，固定 X）。
+      side: "min"（取 lo 侧边）或 "max"（取 hi 侧边）。
+      fixed: 另一轴的固定坐标（米）。
+      picktype(c, axis, fixed)->int: 0=空/仅视图对象，1=边，2=面。每次调用会自行清选择。
+
+    算法：粗扫(24步)定位 空→实体 过渡 → 二分(16次)精确定位边界 → 以边界为中心
+    ±micro_range(0.9mm)/0.1mm 微扫落在 seltype==1 的可选边上。对薄边与旋转/缩放鲁棒。
+    返回边所在坐标 c（米），或 None（该侧无可点选几何）；微扫未命中边时回退返回边界中心。
+    """
+    lo = float(view_outline[axis])
+    hi = float(view_outline[axis + 2])
+    if hi <= lo:
+        return None
+    c_empty = None
+    c_geom = None
+    for k in range(coarse_steps + 1):
+        if side == "min":
+            c = lo + (hi - lo) * k / coarse_steps
+        else:
+            c = hi - (hi - lo) * k / coarse_steps
+        st = picktype(c, axis, fixed)
+        if st == 0:
+            c_empty = c
+        else:
+            c_geom = c
+            if c_empty is not None:
+                break
+    if c_geom is None:
+        return None
+    if c_empty is None:
+        c_empty = lo if side == "min" else hi
+    a, b = c_empty, c_geom
+    for _ in range(binary_iters):
+        m = (a + b) / 2.0
+        if picktype(m, axis, fixed) == 0:
+            a = m
+        else:
+            b = m
+    center = (a + b) / 2.0
+    for k in range(-9, 10):
+        c = center + micro_range * k / 9.0
+        if picktype(c, axis, fixed) == 1:
+            return c
+    return center
+
+
+def find_solid_x(view_outline, ymid, picktype):
+    """@brief 在视图 X 跨度内找一个落在实体面（seltype==2）上的 X，远离竖边/内部空隙。
+
+    作为竖向（H/D）边扫描的固定 X，使点选不咬到竖边（夹爪等含中央空隙的零件）。
+    找不到时回退到 X 中点。
+    """
+    lo = float(view_outline[0])
+    hi = float(view_outline[2])
+    if hi <= lo:
+        return (lo + hi) / 2.0
+    for frac in (0.5, 0.25, 0.75, 0.35, 0.65, 0.15, 0.85):
+        x = lo + (hi - lo) * frac
+        if picktype(x, 0, ymid) == 2:
+            return x
+    return (lo + hi) / 2.0
+
+
+def make_picktype(drawing_model):
+    """@brief 把活动工程图文档接成 find_edge 的 picktype(c, axis, fixed)->seltype 闭包。
+
+    内部用 SelectionManager.GetSelectedObjectCount2 + GetSelectedObjectType6（回退 5/4/3）
+    读首个几何对象类型（跳过 type=12 的视图对象）。每次点选前 ClearSelection。
+    SelectByID2 作用于**活动文档**——调用方须确保该工程图已激活。
+    任何点选异常都降级返回 0（视为空），使扫描优雅地得到部分结果而非抛错。
+    """
+    extension = _safe_member(drawing_model, "Extension", default=None)
+    sel_mgr = _safe_member(drawing_model, "SelectionManager", default=None)
+    empty = create_empty_dispatch_variant()
+    cached_type_method = []
+
+    def _gettype(idx):
+        if cached_type_method:
+            try:
+                return get_com_member(sel_mgr, cached_type_method[0], idx, -1)
+            except Exception:
+                cached_type_method.clear()
+        for mname in ("GetSelectedObjectType6", "GetSelectedObjectType5",
+                      "GetSelectedObjectType4", "GetSelectedObjectType3"):
+            try:
+                value = get_com_member(sel_mgr, mname, idx, -1)
+                cached_type_method.append(mname)
+                return value
+            except Exception:
+                continue
+        return 0
+
+    def seltype():
+        count = _safe_member(sel_mgr, "GetSelectedObjectCount2", -1, default=0)
+        try:
+            count = int(count)
+        except (TypeError, ValueError):
+            count = 0
+        for idx in range(1, count + 1):
+            if _gettype(idx) in (1, 2):
+                return _gettype(idx)
+        return 0
+
+    def picktype(c, axis, fixed):
+        xc = c if axis == 0 else fixed
+        yc = fixed if axis == 0 else c
+        try:
+            get_com_member(drawing_model, "ClearSelection")
+        except Exception:
+            pass
+        try:
+            get_com_member(extension, "SelectByID2", "", "", xc, yc, 0.0, False, 0, empty, 0)
+        except Exception:
+            return 0
+        return seltype()
+
+    return picktype
+
+
+def add_dimension_between(drawing_model, point_a, point_b, dim_x, dim_y, *, retries=4):
+    """@brief 在活动工程图上点选两点并 AddDimension2 标注，失败重试 ≤retries 次。
+
+    point_a/point_b: (x, y) 米；dim_x/dim_y: 尺寸文字放置坐标（米）。
+    边线点选可能在刚创建视图几何未稳态时瞬时失败，故重试。返回 DisplayDimension 或 None。
+    """
+    extension = _safe_member(drawing_model, "Extension", default=None)
+    ax, ay = float(point_a[0]), float(point_a[1])
+    bx, by = float(point_b[0]), float(point_b[1])
+    empty = create_empty_dispatch_variant()
+    for _ in range(max(1, int(retries))):
+        try:
+            get_com_member(drawing_model, "ClearSelection")
+        except Exception:
+            pass
+        get_com_member(extension, "SelectByID2", "", "", ax, ay, 0.0, False, 0, empty, 0)
+        get_com_member(extension, "SelectByID2", "", "", bx, by, 0.0, True, 0, empty, 0)
+        dd = get_com_member(drawing_model, "AddDimension2", dim_x, dim_y, 0.0)
+        if dd:
+            try:
+                get_com_member(drawing_model, "ClearSelection")
+            except Exception:
+                pass
+            return dd
+    return None
+
+
+def _scan_dim_entry(axis, display_dimension, nominal_mm, apply_tolerance):
+    """@brief 单个扫描尺寸的结果条目（内部用）。"""
+    entry = {
+        "axis": axis,
+        "display_dimension_set": bool(display_dimension),
+        "nominal_mm": float(nominal_mm),
+        "tolerance_report": None,
+    }
+    if display_dimension and apply_tolerance:
+        entry["tolerance_report"] = apply_gb1804m(display_dimension, nominal_mm)
+    elif display_dimension:
+        entry["tolerance_report"] = {"status": "skipped", "reason": "apply_tolerance=False"}
+    return entry
+
+
+def scan_view_dimensions(drawing_model, front_view, top_view, *,
+                         nominal_width_mm, nominal_height_mm, nominal_depth_mm,
+                         gap=0.030, apply_tolerance=True):
+    """@brief 坐标扫描式标注前视图 W/H + 俯视图 D，可选套 GB/T 1804-m 对称公差。
+
+    端到端：取两视图轮廓 → find_edge 定位 W/H/D 的左/右、上/下边 → add_dimension_between
+    标注 →（可选）apply_gb1804m。调用前须确保：
+      ① 工程图已激活（SelectByID2 作用于活动文档）；
+      ② 视图已存盘（新建视图仅暴露部分剪影边，存盘后全部边线可选）；
+      ③ 视图比例≥1:2（用 force_view_scale）。
+
+    返回 {status∈pass|review_required|failed, dimensions:[…], edges, outline_front,
+    outline_top, manual_review_required}。三个尺寸全成功标 pass；任一缺失标
+    review_required；全程 pass 仍要求目视复核尺寸位置/重叠/尺寸链。
+    """
+    report = {
+        "status": "review_required",
+        "stage": "edge_scan",
+        "dimensions": [],
+        "edges": {},
+        "outline_front": None,
+        "outline_top": None,
+        "apply_tolerance": bool(apply_tolerance),
+        "nominal": {
+            "width_mm": float(nominal_width_mm),
+            "height_mm": float(nominal_height_mm),
+            "depth_mm": float(nominal_depth_mm),
+        },
+        "manual_review_required": True,
+        "error_code": None,
+    }
+    try:
+        fo = _as_sequence(_safe_member(front_view, "GetOutline", default=[]))
+        to = _as_sequence(_safe_member(top_view, "GetOutline", default=[]))
+        if len(fo) < 4 or len(to) < 4:
+            report["error_code"] = "DRAWING_SCAN_NO_OUTLINE"
+            return report
+        fo = [float(v) for v in fo]
+        to = [float(v) for v in to]
+        report["outline_front"] = fo
+        report["outline_top"] = to
+
+        fmx = (fo[0] + fo[2]) / 2.0
+        fmy = (fo[1] + fo[3]) / 2.0
+        tmy = (to[1] + to[3]) / 2.0
+
+        picktype = make_picktype(drawing_model)
+
+        # W：前视图 X 跨度（固定 Y=中）
+        lw = find_edge(fo, 0, "min", fmy, picktype)
+        rw = find_edge(fo, 0, "max", fmy, picktype)
+        # H：前视图 Y 跨度（固定 X=实体面，避开中央空隙与竖边）
+        hx = find_solid_x(fo, fmy, picktype)
+        bh = find_edge(fo, 1, "min", hx, picktype)
+        th = find_edge(fo, 1, "max", hx, picktype)
+        # D：俯视图 Y 跨度（俯视图深度轴=竖向）
+        dxv = find_solid_x(to, tmy, picktype)
+        bd = find_edge(to, 1, "min", dxv, picktype)
+        td = find_edge(to, 1, "max", dxv, picktype)
+        report["edges"] = {"W": [lw, rw], "H": [bh, th], "D": [bd, td]}
+
+        try:
+            get_com_member(drawing_model, "ClearSelection")
+        except Exception:
+            pass
+
+        dd_w = add_dimension_between(drawing_model, (lw, fmy), (rw, fmy), fmx, fo[1] - gap * 0.6) \
+            if (lw and rw) else None
+        dd_h = add_dimension_between(drawing_model, (hx, bh), (hx, th), fo[0] - gap * 0.6, fmy) \
+            if (bh and th) else None
+        dd_d = add_dimension_between(drawing_model, (dxv, bd), (dxv, td), to[0] - gap * 0.6, tmy) \
+            if (bd and td) else None
+
+        report["dimensions"] = [
+            _scan_dim_entry("W", dd_w, nominal_width_mm, apply_tolerance),
+            _scan_dim_entry("H", dd_h, nominal_height_mm, apply_tolerance),
+            _scan_dim_entry("D", dd_d, nominal_depth_mm, apply_tolerance),
+        ]
+
+        all_set = all(r["display_dimension_set"] for r in report["dimensions"])
+        report["status"] = "pass" if all_set else "review_required"
+        report["error_code"] = None if all_set else "DRAWING_SCAN_PARTIAL"
+    except Exception as exc:
+        report["status"] = "failed"
+        report["error_code"] = "DRAWING_SCAN_FAILED"
+        report["retryable"] = True
+        report["error"] = str(exc)
+    return report

--- a/scripts/sw_inspect.py
+++ b/scripts/sw_inspect.py
@@ -1,0 +1,321 @@
+"""
+SolidWorks 测量与装配检查原语
+零件整体尺寸（临时工程图 GetOutline@1:1）、包围盒、装配组件计数、特征/尺寸枚举。
+能力清单：measurement_and_inspection=pilot。只读；不改、不保存被测文档（临时测量图除外）。
+"""
+import os
+
+try:
+    from .sw_connect import get_com_member, open_document, new_document
+    from .sw_drawing import force_view_scale
+    from .sw_preflight import import_com_dependencies
+except ImportError:
+    from sw_connect import get_com_member, open_document, new_document
+    from sw_drawing import force_view_scale
+    from sw_preflight import import_com_dependencies
+
+pythoncom, _win32com, VARIANT = import_com_dependencies()
+
+
+class InspectionError(RuntimeError):
+    """测量与装配检查错误。"""
+
+
+def _basename_no_ext(path):
+    """@brief 模型文件路径 -> 去扩展名的零件名（GetPathName 计数用）。"""
+    if not path:
+        return "?"
+    name = os.path.basename(path)
+    low = name.lower()
+    for ext in (".sldprt", ".sldasm", ".slddrw"):
+        if low.endswith(ext):
+            return name[: -len(ext)]
+    return os.path.splitext(name)[0]
+
+
+def overall_dimensions(sw, part_path, *, close_part=True):
+    """@brief 零件整体 W/H/D（mm），用临时工程图前+俯视图 GetOutline@1:1 测量。
+
+    前视图给 W(X)×H(Y)，俯视图给 W(X)×D(Y)；W 取两视图平均。临时图测完即关（不保存）。
+    类型化视图恒可用 GetOutline，对未类型化 OpenDoc6 文档上 GetBox 不可解析时仍可靠。
+
+    返回 {status∈pass|review_required|failed, width_mm, height_mm, depth_mm,
+    method, outline_front, outline_top, manual_review_required}。整体尺寸为视图轮廓含
+    余量近似（1:1 下约 +6mm 余量），非严格名义尺寸。
+    """
+    result = {
+        "status": "failed",
+        "stage": "overall_dimensions",
+        "width_mm": None,
+        "height_mm": None,
+        "depth_mm": None,
+        "method": "throwaway_drawing_getoutline_at_1to1",
+        "outline_front": None,
+        "outline_top": None,
+        "manual_review_required": True,
+        "error_code": None,
+        "retryable": False,
+        "limitations": ["视图轮廓含约 6mm 余量，为近似值非严格名义尺寸"],
+    }
+    part_path = os.path.abspath(part_path)
+    pre_open = None
+    drawing = None
+    opened_part_title = None
+    try:
+        try:
+            pre_open = get_com_member(sw, "GetOpenDocumentByName", part_path)
+        except Exception:
+            pre_open = None
+        # CreateDrawViewFromModelView3 需要零件已加载进会话
+        if pre_open is None:
+            open_document(sw, part_path, silent=True)
+            opened_part_title = os.path.basename(part_path)
+        drawing = new_document(sw, "drawing")
+        if drawing is None:
+            result["error_code"] = "MEASURE_NO_DRAWING"
+            return result
+
+        front = get_com_member(drawing, "CreateDrawViewFromModelView3", part_path, "*Front", 0.15, 0.20, 1.0)
+        top = get_com_member(drawing, "CreateDrawViewFromModelView3", part_path, "*Top", 0.15, 0.08, 1.0)
+        if not front or not top:
+            result["error_code"] = "MEASURE_NO_VIEWS"
+            return result
+        # 强制 1:1：CreateDrawViewFromModelView3 的 Scale 被 UseSheetScale 忽略
+        for vw in (front, top):
+            force_view_scale(vw, 1.0, drawing_model=drawing)
+        try:
+            get_com_member(drawing, "EditRebuild3")
+        except Exception:
+            pass
+
+        fo = list(get_com_member(front, "GetOutline"))
+        to = list(get_com_member(top, "GetOutline"))
+        if len(fo) < 4 or len(to) < 4:
+            result["error_code"] = "MEASURE_NO_OUTLINE"
+            return result
+        fo = [float(v) for v in fo]
+        to = [float(v) for v in to]
+        result["outline_front"] = fo
+        result["outline_top"] = to
+        fw = (fo[2] - fo[0]) * 1000.0
+        fh = (fo[3] - fo[1]) * 1000.0
+        tw = (to[2] - to[0]) * 1000.0
+        td = (to[3] - to[1]) * 1000.0
+        result["width_mm"] = (fw + tw) / 2.0
+        result["height_mm"] = fh
+        result["depth_mm"] = td
+        result["status"] = "pass"
+    except Exception as exc:
+        result["error_code"] = "MEASURE_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    finally:
+        # 关闭临时工程图（不保存）
+        if drawing is not None:
+            try:
+                title = get_com_member(drawing, "GetTitle")
+                get_com_member(sw, "CloseDoc", title)
+            except Exception:
+                pass
+        # 仅关闭本次新打开的零件；调用前已打开的保留
+        if close_part and opened_part_title and pre_open is None:
+            try:
+                get_com_member(sw, "CloseDoc", opened_part_title)
+            except Exception:
+                pass
+    return result
+
+
+def bounding_box(model):
+    """@brief 实体包围盒（mm）：GetBox(0)；不可解析时回退 GetBodies2+GetBodyBox 取并集。
+
+    model: 类型化文档（open_document 结果）。未类型化派发上 GetBox 可能不可解析 ->
+    回退到各实体 GetBodyBox 并集；仍失败返回 review_required（建议改用 overall_dimensions）。
+    零件可能非原点对称，必须读 min/max。
+    返回 {status, size_mm:[dx,dy,dz], range_mm:[xmin,ymin,zmin,xmax,ymax,zmax], method}。
+    """
+    result = {
+        "status": "failed",
+        "stage": "bounding_box",
+        "size_mm": None,
+        "range_mm": None,
+        "method": None,
+        "manual_review_required": True,
+        "error_code": None,
+        "retryable": False,
+    }
+    try:
+        if model is None:
+            result["error_code"] = "BBOX_NO_MODEL"
+            return result
+        box = None
+        try:
+            box = get_com_member(model, "GetBox", 0)
+        except Exception:
+            box = None
+        if box and len(box) >= 6:
+            box = [float(v) for v in box]
+            xs, ys, zs = [box[0], box[3]], [box[1], box[4]], [box[2], box[5]]
+            result["range_mm"] = [
+                min(xs) * 1000.0, min(ys) * 1000.0, min(zs) * 1000.0,
+                max(xs) * 1000.0, max(ys) * 1000.0, max(zs) * 1000.0,
+            ]
+            result["size_mm"] = [
+                (max(xs) - min(xs)) * 1000.0,
+                (max(ys) - min(ys)) * 1000.0,
+                (max(zs) - min(zs)) * 1000.0,
+            ]
+            result["method"] = "GetBox(0)"
+            result["status"] = "pass"
+            return result
+
+        # 回退：遍历实体 GetBodyBox 取并集
+        bodies = None
+        try:
+            bodies = get_com_member(model, "GetBodies2", 0, False)
+        except Exception:
+            bodies = None
+        if bodies:
+            mins = [float("inf")] * 3
+            maxs = [float("-inf")] * 3
+            ok = False
+            for body in bodies:
+                bb = None
+                try:
+                    bb = get_com_member(body, "GetBodyBox")
+                except Exception:
+                    bb = None
+                if not bb or len(bb) < 6:
+                    continue
+                bb = [float(v) for v in bb]
+                for i in range(3):
+                    mins[i] = min(mins[i], bb[i])
+                    maxs[i] = max(maxs[i], bb[i + 3])
+                ok = True
+            if ok:
+                result["range_mm"] = [
+                    mins[0] * 1000.0, mins[1] * 1000.0, mins[2] * 1000.0,
+                    maxs[0] * 1000.0, maxs[1] * 1000.0, maxs[2] * 1000.0,
+                ]
+                result["size_mm"] = [(maxs[i] - mins[i]) * 1000.0 for i in range(3)]
+                result["method"] = "GetBodies2+GetBodyBox"
+                result["status"] = "pass"
+                return result
+
+        result["status"] = "review_required"
+        result["error_code"] = "BBOX_UNRESOLVABLE"
+        result["limitations"] = ["GetBox/GetBodyBox 均不可解析，建议改用 overall_dimensions（临时图法）"]
+    except Exception as exc:
+        result["error_code"] = "BBOX_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    return result
+
+
+def count_components(assembly_model, flat=True):
+    """@brief 装配体组件计数（按零件名 basename 去重计数）。
+
+    assembly_model: 已打开的装配体文档。flat=True 扁平（所有实例，含子装配内件，适合采购
+    数量）；False 仅顶层（看结构）。用 IComponent2.GetPathName()（真方法）取路径，不用
+    Name2 属性（动态派发下被当方法会返回访问器对象，破坏计数）。
+    返回 {status∈pass|review_required|failed, counts:{name:n}, total, flat}。
+    """
+    result = {
+        "status": "failed",
+        "stage": "count_components",
+        "counts": {},
+        "total": 0,
+        "flat": bool(flat),
+        "manual_review_required": False,
+        "error_code": None,
+        "retryable": False,
+    }
+    try:
+        if assembly_model is None:
+            result["error_code"] = "COUNT_NO_MODEL"
+            return result
+        comps = get_com_member(assembly_model, "GetComponents", bool(flat))
+        comps = list(comps) if comps else []
+        tally = {}
+        for comp in comps:
+            path = None
+            try:
+                path = get_com_member(comp, "GetPathName")
+            except Exception:
+                path = None
+            name = _basename_no_ext(path)
+            tally[name] = tally.get(name, 0) + 1
+        result["counts"] = tally
+        result["total"] = sum(tally.values())
+        result["status"] = "pass" if tally else "review_required"
+        if not tally:
+            result["error_code"] = "COUNT_EMPTY"
+    except Exception as exc:
+        result["error_code"] = "COUNT_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    return result
+
+
+def enumerate_features(model, max_features=200):
+    """@brief 枚举特征及驱动尺寸（只读）。
+
+    GetFirstFeature→GetNextFeature 链；feat.Name(属性)、GetTypeName2()(方法)、
+    GetDimensions()→FullName/SystemValue(属性，SystemValue 单位米->换算 mm)。
+    返回 {status, features:[{index, name, type, dimensions:[{name, value_mm}]}],
+    count, truncated}。max_features 限制枚举数；超出 truncated=True。
+    """
+    result = {
+        "status": "failed",
+        "stage": "enumerate_features",
+        "features": [],
+        "count": 0,
+        "truncated": False,
+        "manual_review_required": False,
+        "error_code": None,
+        "retryable": False,
+    }
+    try:
+        if model is None:
+            result["error_code"] = "FEAT_NO_MODEL"
+            return result
+        feat = get_com_member(model, "GetFirstFeature")
+        idx = 0
+        while feat is not None and idx < int(max_features):
+            entry = {"index": idx, "name": "", "type": "", "dimensions": []}
+            try:
+                entry["name"] = str(get_com_member(feat, "Name"))
+            except Exception:
+                entry["name"] = ""
+            try:
+                entry["type"] = str(get_com_member(feat, "GetTypeName2"))
+            except Exception:
+                entry["type"] = ""
+            try:
+                dims = get_com_member(feat, "GetDimensions")
+                for dim in (dims or []):
+                    try:
+                        full = str(get_com_member(dim, "FullName"))
+                    except Exception:
+                        full = ""
+                    try:
+                        val_mm = float(get_com_member(dim, "SystemValue")) * 1000.0
+                    except Exception:
+                        val_mm = None
+                    entry["dimensions"].append({"name": full, "value_mm": val_mm})
+            except Exception:
+                pass
+            result["features"].append(entry)
+            idx += 1
+            try:
+                feat = get_com_member(feat, "GetNextFeature")
+            except Exception:
+                feat = None
+        result["truncated"] = feat is not None  # 仍有未枚举特征
+        result["count"] = idx
+        result["status"] = "pass"
+    except Exception as exc:
+        result["error_code"] = "FEAT_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    return result

--- a/scripts/sw_mass_properties.py
+++ b/scripts/sw_mass_properties.py
@@ -1,0 +1,101 @@
+"""
+SolidWorks 质量属性读取工具
+读取零件/装配体的质量、体积、表面积、重心。能力清单：mass_properties=pilot。
+只读不改；不保存、不修改文档。质量依赖材料密度，未设材料时质量无意义。
+"""
+try:
+    from .sw_connect import get_com_member
+    from .sw_preflight import import_com_dependencies
+except ImportError:
+    from sw_connect import get_com_member
+    from sw_preflight import import_com_dependencies
+
+pythoncom, _win32com, VARIANT = import_com_dependencies()
+
+
+class MassPropertiesError(RuntimeError):
+    """质量属性读取错误。"""
+
+
+def _read_material(model):
+    """@brief 尽力读取材料名（"" 表示未赋材料）。
+
+    IModelDoc2.Material（属性）或 GetMaterialPropertyName2(config)（方法，返回
+    (name, database) 元组）。任一取到非空即返回；都失败返回 ""。
+    """
+    if model is None:
+        return ""
+    for accessor, args in (("Material", ()), ("GetMaterialPropertyName2", ("",))):
+        try:
+            value = get_com_member(model, accessor, *args)
+        except Exception:
+            value = None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, (tuple, list)) and value and isinstance(value[0], str) and value[0].strip():
+            return value[0].strip()
+    return ""
+
+
+def mass_properties(model, *, accuracy=0, default_density=0.0):
+    """@brief 读取质量/体积/表面积/重心。
+
+    model: 已打开的零件或装配体文档（IModelDoc2，open_document 的结果）。经
+    get_com_member(model, "Extension") 取 IModelDocExtension（属性，不要当方法）。
+    accuracy: 0=普通精度。default_density: 几何无材料时的兜底密度（kg/m³），通常 0.0。
+
+    返回证据字典：volume_mm3 / surface_mm2 / center_of_mass_mm 恒为几何值（有意义）；
+    mass_kg 仅在材料已赋且 >0 时 mass_meaningful=True（status=pass），否则
+    status=review_required。质量始终须人工复核材料密度（manual_review_required=True）。
+    """
+    result = {
+        "status": "failed",
+        "stage": "mass_properties",
+        "mass_kg": None,
+        "volume_mm3": None,
+        "surface_mm2": None,
+        "center_of_mass_mm": None,
+        "mass_meaningful": False,
+        "material": "",
+        "accuracy": int(accuracy),
+        "manual_review_required": True,
+        "error_code": None,
+        "retryable": False,
+        "limitations": [
+            "质量依赖材料密度；未设材料时 mass_kg 无意义",
+            "密度赋值（InsertMaterial）尚未封装，关联 appearance 能力为 TODO",
+        ],
+    }
+    try:
+        if model is None:
+            result["error_code"] = "MASS_NO_MODEL"
+            return result
+        extension = get_com_member(model, "Extension")
+        if extension is None:
+            result["error_code"] = "MASS_NO_EXTENSION"
+            return result
+        status_ref = VARIANT(pythoncom.VT_BYREF | pythoncom.VT_I4, 0)
+        props = get_com_member(
+            extension, "GetMassProperties2", int(accuracy), status_ref, float(default_density)
+        )
+        if not props or len(props) < 6:
+            result["error_code"] = "MASS_NO_PROPERTIES"
+            return result
+        props = [float(v) for v in props]
+        # [0,1,2]=重心 m；[3]=体积 m³；[4]=表面积 m²；[5]=质量 kg
+        result["center_of_mass_mm"] = [props[0] * 1000.0, props[1] * 1000.0, props[2] * 1000.0]
+        result["volume_mm3"] = props[3] * 1e9
+        result["surface_mm2"] = props[4] * 1e6
+        result["mass_kg"] = props[5]
+        material = _read_material(model)
+        result["material"] = material
+        meaningful = bool(material) and (props[5] is not None and props[5] > 0)
+        result["mass_meaningful"] = meaningful
+        result["status"] = "pass" if meaningful else "review_required"
+        if not meaningful:
+            result["error_code"] = "MASS_MATERIAL_UNASSIGNED" if not material else "MASS_NONPOSITIVE"
+    except Exception as exc:
+        result["error_code"] = "MASS_READ_FAILED"
+        result["retryable"] = True
+        result["error"] = str(exc)
+    return result

--- a/tests/test_dimension_tolerances.py
+++ b/tests/test_dimension_tolerances.py
@@ -1,0 +1,115 @@
+"""尺寸公差标注无 COM 测试：GB/T 1804-m 查表 + set_dimension_tolerance / apply_gb1804m。"""
+from scripts.sw_drawing import (
+    gb1804m_band,
+    set_dimension_tolerance,
+    apply_gb1804m,
+    SW_TOL_SYMMETRIC,
+    SW_TOL_BILATERAL,
+)
+
+
+# ---- GB/T 1804-m 查表（纯函数）----
+
+def test_gb1804m_band_table():
+    assert gb1804m_band(3.0) == 0.1      # <=6
+    assert gb1804m_band(6.0) == 0.1      # 边界 <=6
+    assert gb1804m_band(6.01) == 0.2     # >6, <=30
+    assert gb1804m_band(30.0) == 0.2     # 边界 <=30
+    assert gb1804m_band(45.0) == 0.3     # >30, <=120 区间
+    assert gb1804m_band(120.0) == 0.3    # 边界 <=120
+    assert gb1804m_band(250.0) == 0.5    # <=400
+    assert gb1804m_band(400.0) == 0.5    # 边界 <=400
+    assert gb1804m_band(401.0) == 0.8    # >400
+    assert gb1804m_band(1000.0) == 0.8
+
+
+def test_gb1804m_band_negative_is_absolute():
+    # 名义尺寸取绝对值分档
+    assert gb1804m_band(-45.0) == 0.3
+
+
+# ---- 假 IDimension：记录 SetToleranceType / SetToleranceValues 调用（米）----
+
+class FakeIDimension:
+    def __init__(self):
+        self.tol_type = None
+        self.plus_m = None
+        self.minus_m = None
+
+    def SetToleranceType(self, t):
+        self.tol_type = t
+        return True
+
+    def SetToleranceValues(self, plus_m, minus_m):
+        self.plus_m = plus_m
+        self.minus_m = minus_m
+        return True
+
+
+class FakeDisplayDimension:
+    def __init__(self):
+        self._dim = FakeIDimension()
+
+    def GetDimension(self):
+        return self._dim
+
+
+def test_set_dimension_tolerance_symmetric_auto_band():
+    dd = FakeDisplayDimension()
+    # 45mm 名义 -> GB/T 1804-m ±0.3（<=120 分档，自动）
+    r = set_dimension_tolerance(dd, nominal_mm=45.0)
+    assert r["status"] == "pass"
+    assert r["tolerance_type"] == SW_TOL_SYMMETRIC
+    assert r["plus_mm"] == 0.3
+    assert r["minus_mm"] == 0.3
+    assert r["band_source"] == "gb1804m_m"   # 自动分档
+    # 内部换算米调用：±0.3mm -> +0.0003 / -0.0003
+    dim = dd.GetDimension()
+    assert dim.tol_type == SW_TOL_SYMMETRIC
+    assert abs(dim.plus_m - 0.0003) < 1e-12
+    assert abs(dim.minus_m - (-0.0003)) < 1e-12
+
+
+def test_set_dimension_tolerance_explicit_bilateral():
+    dd = FakeDisplayDimension()
+    r = set_dimension_tolerance(dd, 45.0, tol_type=SW_TOL_BILATERAL, plus_mm=0.2, minus_mm=0.1)
+    assert r["status"] == "pass"
+    assert r["plus_mm"] == 0.2
+    assert r["minus_mm"] == 0.1
+    assert r["band_source"] == "explicit"    # 显式给定，不查表
+    dim = dd.GetDimension()
+    assert dim.tol_type == SW_TOL_BILATERAL
+    assert abs(dim.plus_m - 0.0002) < 1e-12
+    assert abs(dim.minus_m - (-0.0001)) < 1e-12
+
+
+def test_set_dimension_tolerance_band_by_small_nominal():
+    dd = FakeDisplayDimension()
+    # 5mm -> ±0.1
+    r = set_dimension_tolerance(dd, nominal_mm=5.0)
+    assert r["status"] == "pass"
+    assert r["plus_mm"] == 0.1
+    assert r["minus_mm"] == 0.1
+    dim = dd.GetDimension()
+    assert abs(dim.plus_m - 0.0001) < 1e-12
+
+
+def test_apply_gb1804m_is_symmetric_wrapper():
+    dd = FakeDisplayDimension()
+    r = apply_gb1804m(dd, nominal_mm=250.0)   # <=400 -> ±0.5
+    assert r["status"] == "pass"
+    assert r["tolerance_type"] == SW_TOL_SYMMETRIC
+    assert r["plus_mm"] == 0.5
+    dim = dd.GetDimension()
+    assert abs(dim.plus_m - 0.0005) < 1e-12
+
+
+def test_set_dimension_tolerance_no_dimension_object():
+    # GetDimension 返回 None -> 结构化失败而非抛错
+    class EmptyDisplayDim:
+        def GetDimension(self):
+            return None
+
+    r = set_dimension_tolerance(EmptyDisplayDim(), nominal_mm=45.0)
+    assert r["status"] == "failed"
+    assert r["error_code"] == "DRAWING_TOLERANCE_NO_DIMENSION"

--- a/tests/test_edge_scan_dimensioning.py
+++ b/tests/test_edge_scan_dimensioning.py
@@ -1,0 +1,215 @@
+"""坐标扫描式尺寸标注无 COM 测试。
+
+find_edge / find_solid_x 为纯函数（注入 picktype），直接测算法；
+pickability_ok / force_view_scale 用 FakeView（ScaleRatio）测；
+scan_view_dimensions 用模拟选择状态的 FakeDrawing 测端到端编排。
+"""
+from scripts.sw_drawing import (
+    find_edge,
+    find_solid_x,
+    pickability_ok,
+    force_view_scale,
+    scan_view_dimensions,
+)
+
+
+# ---- 纯 picktype：模拟一个矩形零件的选择类型 ----
+
+def _box_picktype(xmin, xmax, ymin, ymax, tol=0.0006):
+    """@brief 矩形零件 picktype：空=0、边=1、面=2。"""
+    def picktype(c, axis, fixed):
+        if axis == 0:
+            x, y = c, fixed
+        else:
+            x, y = fixed, c
+        if not ((xmin - tol) <= x <= (xmax + tol) and (ymin - tol) <= y <= (ymax + tol)):
+            return 0
+        near = (abs(x - xmin) < tol or abs(x - xmax) < tol
+                or abs(y - ymin) < tol or abs(y - ymax) < tol)
+        return 1 if near else 2
+    return picktype
+
+
+# 视图轮廓含余量 [0,0,0.1,0.08]；零件实体 x[0.02,0.08] y[0.01,0.07]
+_OUTLINE = [0.0, 0.0, 0.1, 0.08]
+_PICK = _box_picktype(0.02, 0.08, 0.01, 0.07)
+
+
+def test_find_edge_min_max_x():
+    fmy = (_OUTLINE[1] + _OUTLINE[3]) / 2.0   # 0.04，落在实体 y 区间
+    left = find_edge(_OUTLINE, 0, "min", fmy, _PICK)
+    right = find_edge(_OUTLINE, 0, "max", fmy, _PICK)
+    assert left is not None and right is not None
+    # 落在真实边（0.02 / 0.08）的微扫范围内
+    assert abs(left - 0.02) < 0.001
+    assert abs(right - 0.08) < 0.001
+    assert left < right
+
+
+def test_find_edge_min_max_y():
+    # 固定 X 落在实体面上
+    hx = find_solid_x(_OUTLINE, (_OUTLINE[1] + _OUTLINE[3]) / 2.0, _PICK)
+    bottom = find_edge(_OUTLINE, 1, "min", hx, _PICK)
+    top = find_edge(_OUTLINE, 1, "max", hx, _PICK)
+    assert bottom is not None and top is not None
+    assert abs(bottom - 0.01) < 0.001
+    assert abs(top - 0.07) < 0.001
+
+
+def test_find_edge_no_geometry_returns_none():
+    empty = lambda c, axis, fixed: 0
+    assert find_edge(_OUTLINE, 0, "min", 0.04, empty) is None
+
+
+def test_find_solid_x_lands_on_face():
+    ymid = (_OUTLINE[1] + _OUTLINE[3]) / 2.0
+    x = find_solid_x(_OUTLINE, ymid, _PICK)
+    # 落在实体面区间内（严格内部，远离竖边）
+    assert 0.02 < x < 0.08
+
+
+def test_find_solid_x_fallback_midpoint_when_no_face():
+    # 永远只返回边（1）没有面（2）-> 回退中点
+    edge_only = lambda c, axis, fixed: 1
+    x = find_solid_x(_OUTLINE, 0.04, edge_only)
+    assert abs(x - 0.05) < 1e-9   # 轮廓 X 中点
+
+
+# ---- pickability_ok / force_view_scale：FakeView 读/写 ScaleRatio ----
+
+class _ScaleView:
+    def __init__(self, ratio):
+        self.ScaleRatio = ratio
+        self.UseSheetScale = True
+        self.UseParentScale = True
+        self._decimal = None
+
+    # ScaleDecimal 属性：force_view_scale 写它；回读走 ScaleRatio
+    def _set_decimal(self, v):
+        self._decimal = float(v)
+        d = round(1.0 / float(v)) if v else 1
+        self.ScaleRatio = (1.0, max(1, d))
+    ScaleDecimal = property(lambda self: self._decimal, _set_decimal)
+
+
+def test_pickability_ok_pass_and_blocked():
+    assert pickability_ok(_ScaleView((1.0, 1.0)))["status"] == "pass"     # 1:1
+    assert pickability_ok(_ScaleView((1.0, 2.0)))["status"] == "pass"     # 1:2 边界
+    blocked = pickability_ok(_ScaleView((1.0, 3.0)))                      # 1:3 < 1:2
+    assert blocked["status"] == "blocked"
+    assert blocked["scale"] < 0.5
+
+
+def test_force_view_scale_sets_decimal_and_verifies():
+    vw = _ScaleView((1.0, 3.0))   # 初始 1:3（不可选）
+    r = force_view_scale(vw, 1.0)
+    assert r["status"] == "pass"
+    assert r["verified"] is True
+    assert vw.UseSheetScale is False
+    assert vw.UseParentScale is False
+    # 回读比例应为 1:1
+    assert pickability_ok(vw)["status"] == "pass"
+
+
+# ---- scan_view_dimensions：模拟选择状态的 FakeDrawing（前/俯视图分占图纸两区）----
+
+class _ScanView:
+    def __init__(self, outline):
+        self._ol = outline
+
+    def GetOutline(self):
+        return self._ol
+
+
+class _ScanDrawing:
+    """@brief 模拟工程图选择：SelectByID2(x,y) -> 按 (x,y) 所在视图区返回 seltype。
+
+    前视图区 y in [0.12,0.20]，实体 x[0.12,0.18] y[0.13,0.19]；
+    俯视图区 y in [0.02,0.10]，实体 x[0.12,0.18] y[0.03,0.09]。
+    """
+    TOL = 0.0006
+
+    def __init__(self):
+        self.Extension = self
+        self.SelectionManager = self
+        self._sel = []
+
+    # --- SelectionManager 接口 ---
+    def GetSelectedObjectCount2(self, mark):
+        return len(self._sel)
+
+    def GetSelectedObjectType6(self, idx, mark):
+        return self._sel[idx - 1] if 1 <= idx <= len(self._sel) else 0
+
+    # --- Extension.SelectByID2（9 参）---
+    def SelectByID2(self, name, typ, x, y, z, append, mark, callout, options):
+        t = self._seltype_at(float(x), float(y))
+        self._sel = self._sel + [t] if append else [t]
+        return True
+
+    # --- 文档接口 ---
+    def ClearSelection(self):
+        self._sel = []
+
+    def AddDimension2(self, x, y, z):
+        # 返回一个带 GetDimension 的假 DisplayDimension（供公差套用）
+        class DD:
+            def GetDimension(self_inner):
+                class Dim:
+                    def SetToleranceType(self_inner2, t):
+                        self.t = t
+                        return True
+
+                    def SetToleranceValues(self_inner2, p, m):
+                        self.p, self.m = p, m
+                        return True
+                return Dim()
+        return DD()
+
+    def _seltype_at(self, x, y):
+        if 0.12 <= y <= 0.20:
+            bxmin, bxmax, bymin, bymax = 0.12, 0.18, 0.13, 0.19
+        elif 0.02 <= y <= 0.10:
+            bxmin, bxmax, bymin, bymax = 0.12, 0.18, 0.03, 0.09
+        else:
+            return 0
+        if not (bxmin - self.TOL <= x <= bxmax + self.TOL
+                and bymin - self.TOL <= y <= bymax + self.TOL):
+            return 0
+        near = (abs(x - bxmin) < self.TOL or abs(x - bxmax) < self.TOL
+                or abs(y - bymin) < self.TOL or abs(y - bymax) < self.TOL)
+        return 1 if near else 2
+
+
+def test_scan_view_dimensions_end_to_end():
+    front = _ScanView([0.10, 0.12, 0.20, 0.20])
+    top = _ScanView([0.10, 0.02, 0.20, 0.10])
+    dwg = _ScanDrawing()
+    report = scan_view_dimensions(
+        dwg, front, top,
+        nominal_width_mm=60.0, nominal_height_mm=60.0, nominal_depth_mm=60.0,
+        apply_tolerance=True,
+    )
+    assert report["status"] == "pass"
+    assert len(report["dimensions"]) == 3
+    for d in report["dimensions"]:
+        assert d["display_dimension_set"] is True
+        tr = d["tolerance_report"]
+        assert tr["status"] == "pass"
+        assert tr["plus_mm"] == 0.3          # 60mm -> GB/T 1804-m ±0.3
+    # 边坐标定位在两区实体范围内
+    lw, rw = report["edges"]["W"]
+    assert abs(lw - 0.12) < 0.001 and abs(rw - 0.18) < 0.001
+
+
+def test_scan_view_dimensions_no_outline():
+    class EmptyView:
+        def GetOutline(self):
+            return []
+
+    report = scan_view_dimensions(
+        _ScanDrawing(), EmptyView(), EmptyView(),
+        nominal_width_mm=60.0, nominal_height_mm=60.0, nominal_depth_mm=60.0,
+    )
+    assert report["status"] == "review_required"
+    assert report["error_code"] == "DRAWING_SCAN_NO_OUTLINE"

--- a/tests/test_mass_properties.py
+++ b/tests/test_mass_properties.py
@@ -1,0 +1,59 @@
+"""质量属性无 COM 测试：mass_properties 经假 Extension 读 GetMassProperties2。"""
+from scripts.sw_mass_properties import mass_properties
+
+
+class _FakeExt:
+    def __init__(self, props):
+        self._props = props
+
+    def GetMassProperties2(self, accuracy, status_ref, default_density):
+        return self._props
+
+
+class _FakeModel:
+    def __init__(self, props, material="AISI 1045"):
+        self.Extension = _FakeExt(props)
+        self.Material = material
+
+
+def test_mass_properties_with_material_pass():
+    # 0.01m 立方体钢：vol=1e-6 m3, area=6e-4 m2, mass~7.85e-3 kg, cog=(0,0,0)
+    props = [0.0, 0.0, 0.0, 1e-6, 6e-4, 0.00785]
+    r = mass_properties(_FakeModel(props, material="AISI 1045"))
+    assert r["status"] == "pass"
+    assert r["mass_meaningful"] is True
+    assert r["material"] == "AISI 1045"
+    assert abs(r["volume_mm3"] - 1000.0) < 1e-6      # 1e-6 m3 -> 1000 mm3
+    assert abs(r["surface_mm2"] - 600.0) < 1e-6      # 6e-4 m2 -> 600 mm2
+    assert abs(r["mass_kg"] - 0.00785) < 1e-9
+    assert r["center_of_mass_mm"] == [0.0, 0.0, 0.0]
+
+
+def test_mass_properties_no_material_review():
+    # 几何有效但未赋材料 -> 质量无意义
+    props = [0.0, 0.0, 0.0, 1e-6, 6e-4, 0.00785]
+    r = mass_properties(_FakeModel(props, material=""))
+    assert r["status"] == "review_required"
+    assert r["mass_meaningful"] is False
+    assert r["error_code"] == "MASS_MATERIAL_UNASSIGNED"
+    # 几何值仍应填出
+    assert abs(r["volume_mm3"] - 1000.0) < 1e-6
+
+
+def test_mass_properties_nonpositive_mass_review():
+    # 材料已设但质量<=0（密度未配）-> 非正质量
+    props = [0.0, 0.0, 0.0, 1e-6, 6e-4, 0.0]
+    r = mass_properties(_FakeModel(props, material="AISI 1045"))
+    assert r["status"] == "review_required"
+    assert r["error_code"] == "MASS_NONPOSITIVE"
+
+
+def test_mass_properties_extension_none_failed():
+    # Extension 属性读出 None -> 结构化失败
+    class ExtNone:
+        Material = "AISI 1045"
+        Extension = None
+
+    r = mass_properties(ExtNone())
+    assert r["status"] == "failed"
+    assert r["error_code"] == "MASS_NO_EXTENSION"

--- a/tests/test_measurement_inspection.py
+++ b/tests/test_measurement_inspection.py
@@ -1,0 +1,230 @@
+"""测量与装配检查原语无 COM 测试。
+
+bounding_box / count_components / enumerate_features 用假文档直接测；
+overall_dimensions 经 monkeypatch 注入假的 open_document / new_document /
+force_view_scale，断言前+俯视图 GetOutline@1:1 的 W/H/D 换算。
+"""
+import scripts.sw_inspect as sw_inspect
+from scripts.sw_inspect import (
+    overall_dimensions,
+    bounding_box,
+    count_components,
+    enumerate_features,
+)
+
+
+# ---- bounding_box ----
+
+class _BoxModel:
+    def __init__(self, box=None, bodies=None):
+        self._box = box
+        self._bodies = bodies
+
+    def GetBox(self, arg):
+        if self._box is None:
+            raise RuntimeError("GetBox 不可解析（未类型化派发）")
+        return self._box
+
+    def GetBodies2(self, code, visible):
+        return self._bodies
+
+
+class _Body:
+    def __init__(self, bb):
+        self._bb = bb
+
+    def GetBodyBox(self):
+        return self._bb
+
+
+def test_bounding_box_getbox_ok():
+    # 100x100x150mm，原点对称（-0.05..0.05, -0.05..0.05, -0.075..0.075）米
+    m = _BoxModel(box=[-0.05, -0.05, -0.075, 0.05, 0.05, 0.075])
+    r = bounding_box(m)
+    assert r["status"] == "pass"
+    assert r["method"] == "GetBox(0)"
+    assert r["size_mm"] == [100.0, 100.0, 150.0]
+    assert r["range_mm"] == [-50.0, -50.0, -75.0, 50.0, 50.0, 75.0]
+
+
+def test_bounding_box_non_origin_symmetric():
+    # 非原点对称 -> 仍须读 min/max
+    m = _BoxModel(box=[0.0, 0.0, 0.0, 0.100, 0.050, 0.150])
+    r = bounding_box(m)
+    assert r["status"] == "pass"
+    assert r["size_mm"] == [100.0, 50.0, 150.0]
+    assert r["range_mm"] == [0.0, 0.0, 0.0, 100.0, 50.0, 150.0]
+
+
+def test_bounding_box_bodies_fallback():
+    # GetBox 不可解析 -> 回退 GetBodies2 + GetBodyBox 取并集
+    bodies = [
+        _Body([0.0, 0.0, 0.0, 0.050, 0.050, 0.050]),
+        _Body([0.050, 0.0, 0.0, 0.100, 0.050, 0.050]),
+    ]
+    m = _BoxModel(box=None, bodies=bodies)
+    r = bounding_box(m)
+    assert r["status"] == "pass"
+    assert r["method"] == "GetBodies2+GetBodyBox"
+    assert r["size_mm"] == [100.0, 50.0, 50.0]
+    assert r["range_mm"] == [0.0, 0.0, 0.0, 100.0, 50.0, 50.0]
+
+
+def test_bounding_box_unresolvable():
+    m = _BoxModel(box=None, bodies=None)
+    r = bounding_box(m)
+    assert r["status"] == "review_required"
+    assert r["error_code"] == "BBOX_UNRESOLVABLE"
+
+
+# ---- count_components ----
+
+class _Comp:
+    def __init__(self, path):
+        self._path = path
+
+    def GetPathName(self):
+        return self._path
+
+
+class _Assembly:
+    def __init__(self, comps):
+        self._comps = comps
+
+    def GetComponents(self, flat):
+        return self._comps
+
+
+def test_count_components_flat_tally():
+    asm = _Assembly([
+        _Comp(r"C:\lib\螺栓M8.sldprt"),
+        _Comp(r"C:\lib\螺栓M8.sldprt"),
+        _Comp(r"D:\motor\钻头M5.sldprt"),
+    ])
+    r = count_components(asm, flat=True)
+    assert r["status"] == "pass"
+    assert r["total"] == 3
+    assert r["counts"] == {"螺栓M8": 2, "钻头M5": 1}
+    assert r["flat"] is True
+
+
+def test_count_components_empty_review():
+    r = count_components(_Assembly([]), flat=True)
+    assert r["status"] == "review_required"
+    assert r["error_code"] == "COUNT_EMPTY"
+
+
+# ---- enumerate_features ----
+
+class _Dim:
+    FullName = "D1@Sketch1"
+    SystemValue = 0.080   # 米 -> 80mm
+
+
+class _Feat:
+    def __init__(self, name, ftype, dims, nxt=None):
+        self.Name = name
+        self._type = ftype
+        self._dims = dims
+        self._nxt = nxt
+
+    def GetTypeName2(self):
+        return self._type
+
+    def GetDimensions(self):
+        return self._dims
+
+    def GetNextFeature(self):
+        return self._nxt
+
+
+class _FeatModel:
+    def __init__(self, first):
+        self._first = first
+
+    def GetFirstFeature(self):
+        return self._first
+
+
+def test_enumerate_features_chain():
+    f2 = _Feat("Boss-Extrude1", "Extrusion", [_Dim()], nxt=None)
+    f1 = _Feat("Sketch1", "ProfileFeature", [], nxt=f2)
+    r = enumerate_features(_FeatModel(f1), max_features=10)
+    assert r["status"] == "pass"
+    assert r["count"] == 2
+    assert r["truncated"] is False
+    assert r["features"][0]["name"] == "Sketch1"
+    assert r["features"][1]["name"] == "Boss-Extrude1"
+    assert r["features"][1]["dimensions"][0]["value_mm"] == 80.0
+
+
+def test_enumerate_features_truncation():
+    # 链长于 max_features -> truncated
+    tail = _Feat("F3", "T", [], nxt=None)
+    mid = _Feat("F2", "T", [], nxt=tail)
+    head = _Feat("F1", "T", [], nxt=mid)
+    r = enumerate_features(_FeatModel(head), max_features=2)
+    assert r["count"] == 2
+    assert r["truncated"] is True
+
+
+# ---- overall_dimensions（monkeypatch 真实 open/new/force 依赖）----
+
+class _OLView:
+    def __init__(self, outline):
+        self._ol = outline
+
+    def GetOutline(self):
+        return self._ol
+
+
+class _ThrowawayDrawing:
+    def __init__(self, front_ol, top_ol):
+        self._front = front_ol
+        self._top = top_ol
+        self.created = []
+
+    def CreateDrawViewFromModelView3(self, path, name, x, y, scale):
+        self.created.append(name)
+        return _OLView(self._front if name == "*Front" else self._top)
+
+    def EditRebuild3(self):
+        return True
+
+    def GetTitle(self):
+        return "throwaway.SLDDRW"
+
+
+class _FakeSW:
+    def __init__(self):
+        self.closed = []
+
+    def GetOpenDocumentByName(self, path):
+        return None
+
+    def CloseDoc(self, title):
+        self.closed.append(title)
+        return True
+
+
+def test_overall_dimensions_from_outlines(monkeypatch):
+    part = r"C:\tmp\block.sldprt"   # 不需真实文件：open_document 被 patch 不真读
+    drawing = _ThrowawayDrawing(
+        front_ol=[0.0, 0.0, 0.060, 0.010],   # W=60mm H=10mm
+        top_ol=[0.0, 0.0, 0.060, 0.040],     # W=60mm D=40mm
+    )
+    monkeypatch.setattr(sw_inspect, "open_document", lambda sw, p, silent=False: object())
+    monkeypatch.setattr(sw_inspect, "new_document", lambda sw, doc_type: drawing)
+    monkeypatch.setattr(sw_inspect, "force_view_scale", lambda vw, s, drawing_model=None: {"status": "pass"})
+
+    sw = _FakeSW()
+    r = overall_dimensions(sw, str(part))
+    assert r["status"] == "pass"
+    assert abs(r["width_mm"] - 60.0) < 1e-6     # (60+60)/2
+    assert abs(r["height_mm"] - 10.0) < 1e-6
+    assert abs(r["depth_mm"] - 40.0) < 1e-6
+    assert r["outline_front"] == [0.0, 0.0, 0.060, 0.010]
+    assert set(drawing.created) == {"*Front", "*Top"}
+    # 临时图与本次新开的零件都应被关闭
+    assert "throwaway.SLDDRW" in sw.closed
+    assert "block.sldprt" in sw.closed


### PR DESCRIPTION
## 内容

本 PR 把 SW2024 真机验证过的四项工程图相关能力沉淀进 Skill 层:

### 1. 尺寸公差标注(`scripts/sw_drawing.py`)
- `set_dimension_tolerance` / `apply_gb1804m`:`IDimension.SetToleranceType + SetToleranceValues`(米单位,下差取负)
- GB/T 1804-m 通用公差按名义尺寸分档(≤6±0.1 / ≤30±0.2 / ≤120±0.3 / ≤400±0.5 / >400±0.8)
- 规避两个已实证的坑:ITolerance.Type 属性赋值只写数据不渲染;回读值单位不一致导致错档,带宽按外部已知名义尺寸查表

### 2. 坐标扫描式工程图标注(`scripts/sw_drawing.py`)
- 针对无模型驱动尺寸的零件(导入件/占位件):视图轮廓粗扫→二分→微扫落在可选边→`AddDimension2`(重试)
- 比例 ≥1:2 门禁(`pickability_ok`/`force_view_scale`,ScaleDecimal 强制真实比例)
- 先存盘再扫描、活动文档限制等经验已写入 `references/drawing.md`

### 3. 测量与质量属性只读模块(新文件)
- `scripts/sw_inspect.py`:整体尺寸(临时 1:1 工程图 GetOutline)、包围盒、装配组件计数、特征尺寸枚举
- `scripts/sw_mass_properties.py`:`GetMassProperties2` 质量/体积/表面积/重心,未设材料时 review_required 不伪造数值

### 4. 能力清单与路由
- `capabilities.yaml` 新增 dimension_tolerances / drawing_edge_scan_dimensioning / mass_properties / measurement_and_inspection(均 pilot,SW2024 真机回归)
- SKILL.md 路由与机械图纸底线更新(制造尺寸必须带公差;点选标注比例 ≥1:2)

## 测试

- 新增 4 个纯单测(29 用例,无 COM 依赖):分档表边界、公差 Fake 注入、find_edge/find_solid_x 纯函数、端到端 FakeDrawing
- 真机证据:SW2024 电机项目 5 个自制件工程图(每张 W/H/D 三向 ±GB/T 1804-m,PDF 目视确认)、3 个外购件体积/表面积回归

## 遵循的约束

- 能力均定级 pilot,限制写入 limitations;公差仅覆盖线性尺寸,GD&T 维持 reference_only
- 所有新模块只读或结构化失败(返回错误码不抛异常)