### PR TITLE
修复Star History图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ model.Extension.SelectByID2(
 
 ### ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wzyn20051216/solidworks-automation-skill&type=Date)](https://www.star-history.com/#wzyn20051216/solidworks-automation-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wzyn20051216/solidworks-automation-skill&type=Date)](https://star-history.dera.page/#wzyn20051216/solidworks-automation-skill&Date)
 
 ### ❓ 常见问题
 


### PR DESCRIPTION
当前README中的Star History图表因GitHub星标API限制已失效，无法正常加载。本变更将其切换到使用另一数据源的替代服务，无需API Token即可正常显示，从而恢复图表功能。